### PR TITLE
[net2] Race on err assignment in test suite

### DIFF
--- a/net2/http2/simple_pool_test.go
+++ b/net2/http2/simple_pool_test.go
@@ -33,7 +33,7 @@ func (s *SimplePoolSuite) TestHTTP(c *C) {
 	finished := make(chan bool)
 	for i := 0; i < count; i++ {
 		go func() {
-			_, err = pool.Do(req)
+			_, err := pool.Do(req)
 			c.Assert(err, IsNil)
 			finished <- true
 		}()


### PR DESCRIPTION
In `func (s *SimplePoolSuite) TestHTTP(c *C)`, multiple goroutines were sharing a unique `err error`:

``` go
req, err := http.NewRequest("GET", "/", nil)
// ...
for i := 0; i < count; i++ {
    go func() {
        _, err = pool.Do(req) // reusing err
        c.Assert(err, IsNil)
        finished <- true
    }()
}
```

Resulting in a data race (see `go test -race` output below). This change makes each goroutine use its own `err` error.

```
WARNING: DATA RACE
Write by goroutine 414:
  github.com/dropbox/godropbox/net2/http2.func·008()
      /Users/antoine/gocode/src/github.com/dropbox/godropbox/net2/http2/simple_pool_test.go:37 +0xbb

Previous write by goroutine 83:
  github.com/dropbox/godropbox/net2/http2.func·008()
      /Users/antoine/gocode/src/github.com/dropbox/godropbox/net2/http2/simple_pool_test.go:37 +0xbb

Goroutine 414 (running) created at:
  github.com/dropbox/godropbox/net2/http2.(*SimplePoolSuite).TestHTTP()
      /Users/antoine/gocode/src/github.com/dropbox/godropbox/net2/http2/simple_pool_test.go:39 +0x45e
  runtime.call16()
      /Users/antoine/go/src/pkg/runtime/asm_amd64.s:360 +0x31
  reflect.Value.Call()
      /Users/antoine/go/src/pkg/reflect/value.go:411 +0xed
  gopkg.in/check%2ev1.func·003()
      /Users/antoine/gocode/src/gopkg.in/check.v1/check.go:753 +0x51b
  gopkg.in/check%2ev1.func·001()
      /Users/antoine/gocode/src/gopkg.in/check.v1/check.go:648 +0xf4

Goroutine 83 (finished) created at:
  github.com/dropbox/godropbox/net2/http2.(*SimplePoolSuite).TestHTTP()
      /Users/antoine/gocode/src/github.com/dropbox/godropbox/net2/http2/simple_pool_test.go:39 +0x45e
  runtime.call16()
      /Users/antoine/go/src/pkg/runtime/asm_amd64.s:360 +0x31
  reflect.Value.Call()
      /Users/antoine/go/src/pkg/reflect/value.go:411 +0xed
  gopkg.in/check%2ev1.func·003()
      /Users/antoine/gocode/src/gopkg.in/check.v1/check.go:753 +0x51b
  gopkg.in/check%2ev1.func·001()
      /Users/antoine/gocode/src/gopkg.in/check.v1/check.go:648 +0xf4
```
