### PR TITLE
Add Proxy field to ConnectionParams.

### DIFF
--- a/net2/http2/pool.go
+++ b/net2/http2/pool.go
@@ -3,6 +3,7 @@ package http2
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/dropbox/godropbox/errors"
@@ -47,6 +48,9 @@ type ConnectionParams struct {
 
 	// Dial function to use instead of the default
 	Dial func(network, addr string) (net.Conn, error)
+
+	// Function to determine proxy
+	Proxy func(*http.Request) (*url.URL, error)
 }
 
 type DialError struct {

--- a/net2/http2/simple_pool.go
+++ b/net2/http2/simple_pool.go
@@ -53,11 +53,17 @@ func NewSimplePool(addr string, params ConnectionParams) *SimplePool {
 	transport := new(http.Transport)
 	transport.ResponseHeaderTimeout = params.ResponseTimeout
 	transport.MaxIdleConnsPerHost = params.MaxIdle
-	transport.Proxy = http.ProxyFromEnvironment
+
+	if params.Proxy != nil {
+ 		transport.Proxy = params.Proxy
+ 	} else {
+ 		transport.Proxy = http.ProxyFromEnvironment
+ 	}
+
 	if params.Dial == nil {
 		// dialTimeout could only be used in none proxy requests since it talks directly
 		// to pool.addr
-		if getenvEitherCase("HTTP_PROXY") == "" {
+		if getenvEitherCase("HTTP_PROXY") == "" && transport.Proxy == nil {
 			transport.Dial = pool.dialTimeout
 		}
 	} else {


### PR DESCRIPTION
This would allow the user to be able to specify a proxy if environment variables are not sufficient.
