### PR TITLE
Add HasKey checker to gocheck2

### DIFF
--- a/gocheck2/checkers.go
+++ b/gocheck2/checkers.go
@@ -6,6 +6,7 @@ package gocheck2
 
 import (
 	"bytes"
+	"reflect"
 
 	. "gopkg.in/check.v1"
 )
@@ -95,3 +96,41 @@ func (b *bytesEquals) Info() *CheckerInfo {
 //     c.Assert(nil, BytesEquals, []byte("")) // succeeds
 //     c.Assert(nil, DeepEquals, []byte("")) // fails
 var BytesEquals = &bytesEquals{}
+
+// -----------------------------------------------------------------------
+// HasKey checker.
+
+type hasKey struct{}
+
+func (h *hasKey) Check(params []interface{}, names []string) (bool, string) {
+	if len(params) != 2 {
+		return false, "HasKey takes 2 arguments: a map and a key"
+	}
+
+	mapValue := reflect.ValueOf(params[0])
+	if mapValue.Kind() != reflect.Map {
+		return false, "First argument to HasKey must be a map"
+	}
+
+	keyValue := reflect.ValueOf(params[1])
+	if !keyValue.Type().AssignableTo(mapValue.Type().Key()) {
+		return false, "Second argument must be assignable to the map key type"
+	}
+
+	return mapValue.MapIndex(keyValue).IsValid(), ""
+}
+
+func (h *hasKey) Info() *CheckerInfo {
+	return &CheckerInfo{
+		Name:   "HasKey",
+		Params: []string{"obtained", "key"},
+	}
+}
+
+// The HasKey checker verifies that the obtained map contains the given key.
+//
+// For example:
+//
+//     c.Assert(myMap, HasKey, "foo")
+//
+var HasKey = &hasKey{}

--- a/gocheck2/checkers_test.go
+++ b/gocheck2/checkers_test.go
@@ -1,0 +1,39 @@
+package gocheck2
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into go test runner
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type CheckersSuite struct{}
+
+var _ = Suite(&CheckersSuite{})
+
+func (s *CheckersSuite) SetUpTest(c *C) {
+}
+
+func testHasKey(c *C, expectedResult bool, expectedErr string, params ...interface{}) {
+	actualResult, actualErr := HasKey.Check(params, nil)
+	if actualResult != expectedResult || actualErr != expectedErr {
+		c.Fatalf(
+			"Check returned (%#v, %#v) rather than (%#v, %#v)",
+			actualResult, actualErr, expectedResult, expectedErr)
+	}
+}
+
+func (s *CheckersSuite) TestHasKey(c *C) {
+	testHasKey(c, true, "", map[string]int{"foo": 1}, "foo")
+	testHasKey(c, false, "", map[string]int{"foo": 1}, "bar")
+	testHasKey(c, true, "", map[int][]byte{10: nil}, 10)
+
+	testHasKey(c, false, "First argument to HasKey must be a map", nil, "bar")
+	testHasKey(
+		c, false, "Second argument must be assignable to the map key type",
+		map[string]int{"foo": 1}, 10)
+}


### PR DESCRIPTION
Adding checker to assert that a key exists in a map (e.g. c.Assert(myMap, HasKey, "foo")).
