### PR TITLE
Mock Memcached fixes

### DIFF
--- a/memcache/mock_client.go
+++ b/memcache/mock_client.go
@@ -78,7 +78,7 @@ func (c *MockClient) setHelper(item *Item) MutateResponse {
 		// CAS mismatch
 		return NewMutateResponse(
 			newItem.Key,
-			StatusItemNotStored,
+			StatusKeyExists,
 			0)
 	}
 


### PR DESCRIPTION
If there's a CAS mismatch, the error you receive from memcached is StatusKeyExists. Try it locally with the following:

``` go
package main

import (
    "github.com/dropbox/godropbox/memcache"
    "github.com/dropbox/godropbox/net2"
    "fmt"
)

func main() {
    manager := memcache.NewStaticShardManager(
        []string{"localhost:11211"},
        func(key string, numShard int) (shard int) {
            return 0
        },
        net2.ConnectionOptions{})

    client := memcache.NewShardedClient(manager)

    client.Set(&memcache.Item{
        Key: "key1",
        Value: []byte("value1"),
    })

    resp := client.Get("key1")

    fmt.Println("resp", resp)

    resp2 := client.Set(&memcache.Item{
        Key: "key1",
        Value: []byte("value2"),
        DataVersionId: 24534,
    })

    fmt.Println("resp2", resp2)
    fmt.Println("cas: not stored?",
            resp2.Status() == memcache.StatusItemNotStored)
    fmt.Println("cas: key exists?",
            resp2.Status() == memcache.StatusKeyExists)
}
```
