### PR TITLE
Fix test TestConnectTimeout in net2/http2/simple_pool_test

### DIFF
--- a/net2/http2/simple_pool_test.go
+++ b/net2/http2/simple_pool_test.go
@@ -55,10 +55,12 @@ func (s *SimplePoolSuite) TestHTTP(c *C) {
 }
 
 func (s *SimplePoolSuite) TestConnectTimeout(c *C) {
-	addr := "127.1.1.254:8000"
+	server, addr := test_utils.SetupTestServer(false)
+	defer server.Close()
+
 	params := ConnectionParams{
 		MaxIdle:        1,
-		ConnectTimeout: 1 * time.Microsecond,
+		ConnectTimeout: 1 * time.Nanosecond,
 	}
 	var pool Pool = NewSimplePool(addr, params)
 


### PR DESCRIPTION
The previous version of the test did not test timeout, because it would try to connect to a nonexistent address and thus always get a dial error.

This change sets up a test server, so that the connect will succeed (if there is no timeout). There is a slight risk that this will fail if the connect is really really fast, but that is highly unlikely to happen.

The go library's DialTimeout test is quite complicated: http://golang.org/src/pkg/net/dial_test.go
and this test should be good enough to check whether there is indeed a timeout or not. (If timeout isn't implemented correctly, this test indeed does fail)
