### PR TITLE
Add support for duplicate shard states in BaseShardManager

### DIFF
--- a/memcache/base_shard_manager.go
+++ b/memcache/base_shard_manager.go
@@ -63,7 +63,8 @@ func (m *BaseShardManager) UpdateShardStates(shardStates []ShardState) {
 	}
 
 	for address, state := range diffs {
-		if state == 1 { // New connections
+		if state > 0 { // New connections
+			// State can be greater than 1 for duplicate entries.
 			if err := m.pool.Register("tcp", address); err != nil {
 				m.logError(err)
 			}

--- a/memcache/base_shard_manager_test.go
+++ b/memcache/base_shard_manager_test.go
@@ -1,0 +1,51 @@
+package memcache
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/dropbox/godropbox/container/set"
+	. "github.com/dropbox/godropbox/gocheck2"
+	"github.com/dropbox/godropbox/net2"
+)
+
+type ManagerSuite struct {
+	manager *BaseShardManager
+	pool    *mockPool
+}
+
+var _ = Suite(&ManagerSuite{})
+
+type mockPool struct {
+	net2.ConnectionPool
+	registered set.Set
+}
+
+func newMockPool() *mockPool {
+	return &mockPool{
+		registered: set.NewSet(),
+	}
+}
+
+func (p *mockPool) Register(_, address string) error {
+	p.registered.Add(address)
+	return nil
+}
+
+func (s *ManagerSuite) SetUpTest(c *C) {
+	s.pool = newMockPool()
+	s.manager = &BaseShardManager{
+		pool: s.pool,
+	}
+}
+
+func (s *ManagerSuite) TestRegister(c *C) {
+	shardStates := make([]ShardState, 4)
+	shardStates[0].Address = "foo"
+	shardStates[1].Address = "bar"
+	shardStates[2].Address = "baz"
+	shardStates[3].Address = "foo"
+	s.manager.UpdateShardStates(shardStates)
+
+	expectedRegistered := set.NewSet("foo", "bar", "baz")
+	c.Assert(expectedRegistered.IsEqual(s.pool.registered), IsTrue)
+}


### PR DESCRIPTION
This fixes an issue where a connection is not registered if it has multiple ShardState entries.
