### PR TITLE
Tuple expressions for sql lib

### DIFF
--- a/database/sqlbuilder/expression.go
+++ b/database/sqlbuilder/expression.go
@@ -163,6 +163,9 @@ type tupleExpression struct {
 }
 
 func (tuple *tupleExpression) SerializeSql(out *bytes.Buffer) error {
+	if len(tuple.elements.clauses) < 1 {
+		return errors.Newf("Tuples must include at least one element")
+	}
 	return tuple.elements.SerializeSql(out)
 }
 

--- a/database/sqlbuilder/expression_test.go
+++ b/database/sqlbuilder/expression_test.go
@@ -42,11 +42,14 @@ func (s *ExprSuite) TestConjunctExprSingleElement(c *gc.C) {
 }
 
 func (s *ExprSuite) TestTupleExpr(c *gc.C) {
-	expr := Tuple(table1Col1, Literal(1), Literal("five"))
 
+	expr := Tuple()
 	buf := &bytes.Buffer{}
-
 	err := expr.SerializeSql(buf)
+	c.Assert(err, gc.NotNil)
+
+	expr = Tuple(table1Col1, Literal(1), Literal("five"))
+	err = expr.SerializeSql(buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()


### PR DESCRIPTION
Creates tuple expressions, to enable paging on multiple-column indexes.
