### PR TITLE
Copy() and AndWhere()

### DIFF
--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -153,6 +153,9 @@ func (s *selectStatementImpl) Copy() SelectStatement {
 
 // Further filter the query, instead of replacing the filter
 func (q *selectStatementImpl) AndWhere(expression BoolExpression) SelectStatement {
+	if q.where == nil {
+		return q.Where(expression)
+	}
 	q.where = And(q.where, expression)
 	return q
 }

--- a/database/sqlbuilder/statement_test.go
+++ b/database/sqlbuilder/statement_test.go
@@ -69,7 +69,7 @@ func (s *StmtSuite) TestSelectWhereDate(c *gc.C) {
 }
 
 func (s *StmtSuite) TestSelectAndWhere(c *gc.C) {
-	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123))
+	q := table1.Select(table1Col1).AndWhere(GtL(table1Col1, 123))
 	q.AndWhere(LtL(table1Col1, 321))
 	sql, err := q.String("db")
 


### PR DESCRIPTION
These features should enable outside libraries to automatically page
queries, by copying a base query and adjusting its where clause.
