### PR TITLE
fixed typo in errors_test

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -15,7 +15,7 @@ func TestStackTrace(t *testing.T) {
 		t.Error("error message %s != expected %s", e.Msg, testMsg)
 	}
 
-	if strings.Index(e.Stack, "dropbox/util/errors/errors.go") != -1 {
+	if strings.Index(e.Stack, "godropbox/errors/errors.go") != -1 {
 		t.Error("stack trace generation code should not be in the error stack trace")
 	}
 


### PR DESCRIPTION
The test in TestStackTrace in error_test.go checked for an old path in the result. This has been corrected to the new github location to catch potential errors correctly in this test. 