### PR TITLE
[memcache] Add WARM UP state

### DIFF
--- a/memcache/base_shard_manager.go
+++ b/memcache/base_shard_manager.go
@@ -212,6 +212,10 @@ func (m *BaseShardManager) GetShardsForSentinels(
 						entry.Connection = conn
 					}
 
+					// During WARM_UP state, we do try to write sentinels to
+					// memcache but any failures are ignored. We run memcache
+					// server in this mode for sometime to prime our memcache
+					// and warm up memcache server.
 					if state.State == WarmUpServer {
 						entry.WarmingUp = true
 					}

--- a/memcache/base_shard_manager.go
+++ b/memcache/base_shard_manager.go
@@ -13,6 +13,7 @@ const (
 	ActiveServer    = MemcachedState(0)
 	WriteOnlyServer = MemcachedState(1)
 	DownServer      = MemcachedState(2)
+	WarmUpServer    = MemcachedState(4)
 )
 
 type ShardState struct {
@@ -200,7 +201,8 @@ func (m *BaseShardManager) GetShardsForSentinels(
 			if shardId != -1 {
 				state := m.shardStates[shardId]
 				if state.State == ActiveServer ||
-					state.State == WriteOnlyServer {
+					state.State == WriteOnlyServer ||
+					state.State == WarmUpServer {
 
 					conn, err := m.pool.Get("tcp", state.Address)
 					if err != nil {
@@ -208,6 +210,10 @@ func (m *BaseShardManager) GetShardsForSentinels(
 						entry.ConnErr = err
 					} else {
 						entry.Connection = conn
+					}
+
+					if state.State == WarmUpServer {
+						entry.WarmingUp = true
 					}
 				}
 			}

--- a/memcache/interface.go
+++ b/memcache/interface.go
@@ -242,6 +242,7 @@ type ShardMapping struct {
 	ConnErr    error
 	Keys       []string // Populated for GetShardsForKeys
 	Items      []*Item  // Populated for GetShardsForItems
+	WarmingUp  bool     // Populated for GetShardsForSentinels
 }
 
 // The ShardManager decides which memcache shard a key/item belongs to, and

--- a/memcache/sharded_client_test.go
+++ b/memcache/sharded_client_test.go
@@ -1,0 +1,101 @@
+package memcache
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/dropbox/godropbox/net2"
+)
+
+// MockShardManager
+type MockShardManager struct {
+	ShardManager
+	*C
+
+	shardMap map[int]*ShardMapping
+}
+
+func (m *MockShardManager) GetShardsForSentinels(items []*Item) map[int]*ShardMapping {
+	m.Assert(items, HasLen, 1)
+	return m.shardMap
+}
+
+// BadMemcacheConn fails all write operations.
+type BadMemcacheConn struct {
+	net2.ManagedConn
+}
+
+func (BadMemcacheConn) Write([]byte) (int, error) {
+	return 0, errors.New("Bad conn")
+}
+
+func (BadMemcacheConn) DiscardConnection() error {
+	return nil
+}
+
+// ShardedClientSuite
+type ShardedClientSuite struct {
+	sm *MockShardManager
+	mc Client
+}
+
+var _ = Suite(&ShardedClientSuite{})
+
+func (s *ShardedClientSuite) SetUpTest(c *C) {
+	s.sm = &MockShardManager{C: c}
+	s.mc = NewShardedClient(s.sm)
+}
+
+func (s *ShardedClientSuite) TestSetSentinels(c *C) {
+	items := []*Item{
+		&Item{
+			Key:   "key",
+			Value: []byte("value"),
+		},
+	}
+
+	// In DOWN state, SetSentinels should always succeed.
+	s.sm.shardMap = map[int]*ShardMapping{
+		0: &ShardMapping{
+			ConnErr:    nil,
+			Connection: nil,
+			Items:      items,
+			WarmingUp:  false,
+		},
+	}
+
+	response := s.mc.SetSentinels(items)
+	c.Assert(response, HasLen, 1)
+	c.Assert(response[0].Error(), IsNil)
+	c.Assert(response[0].DataVersionId(), Equals, uint64(0))
+
+	// In WARM_UP state, SetSentinels should succeed with bad connection.
+	s.sm.shardMap = map[int]*ShardMapping{
+		0: &ShardMapping{
+			ConnErr:    nil,
+			Connection: BadMemcacheConn{},
+			Items:      items,
+			WarmingUp:  true,
+		},
+	}
+
+	response = s.mc.SetSentinels(items)
+	c.Assert(response, HasLen, 1)
+	c.Assert(response[0].Error(), IsNil)
+	c.Assert(response[0].DataVersionId(), Equals, uint64(0))
+
+	// In WRITE_ONLY & ACTIVE state, SetSentinels should fail with bad connection.
+	s.sm.shardMap = map[int]*ShardMapping{
+		0: &ShardMapping{
+			ConnErr:    nil,
+			Connection: BadMemcacheConn{},
+			Items:      items,
+			WarmingUp:  false,
+		},
+	}
+
+	response = s.mc.SetSentinels(items)
+	c.Assert(response, HasLen, 1)
+	c.Assert(response[0].Error(), NotNil)
+}


### PR DESCRIPTION
In one of our high QPS memcache use-case we found that going from DOWN to WRITE_ONLY state causes lots of requests to fail (doesn't look like memcache warm-up issue but something to do with high number of connections our clients create). So the idea here is that instead of directly going from DOWN to WRITE_ONLY, you first go to WARM_UP state from DOWN. In WARM_UP state we do try GET/SET operations on memcache but any failure is ignored just like DOWN state. After that we can go from WARM_UP to WRITE_ONLY state and since all the connection pools are already full, we should not see any more failures.