### PR TITLE
[database] Use strongly type Nullable enum rather than raw bools

### DIFF
--- a/database/binlog/bit_fields.go
+++ b/database/binlog/bit_fields.go
@@ -25,7 +25,7 @@ type bitFieldDescriptor struct {
 }
 
 // This returns a field descriptor for FieldType_BIT (i.e., Field_bit_as_char)
-func NewBitFieldDescriptor(nullable bool, metadata []byte) (
+func NewBitFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {

--- a/database/binlog/field_descriptor.go
+++ b/database/binlog/field_descriptor.go
@@ -4,6 +4,13 @@ import (
 	mysql_proto "github.com/dropbox/godropbox/proto/mysql"
 )
 
+type NullableColumn bool
+
+const (
+	Nullable    NullableColumn = true
+	NotNullable NullableColumn = false
+)
+
 // FieldDescriptor defines the common interface for interpreting all mysql
 // field types.
 type FieldDescriptor interface {
@@ -23,7 +30,7 @@ type FieldDescriptor interface {
 // NOTE: ParseValue is left unimplemented.
 type baseFieldDescriptor struct {
 	fieldType  mysql_proto.FieldType_Type
-	isNullable bool
+	isNullable NullableColumn
 }
 
 func (d *baseFieldDescriptor) Type() mysql_proto.FieldType_Type {
@@ -31,7 +38,7 @@ func (d *baseFieldDescriptor) Type() mysql_proto.FieldType_Type {
 }
 
 func (d *baseFieldDescriptor) IsNullable() bool {
-	return d.isNullable
+	return d.isNullable == Nullable
 }
 
 type ColumnDescriptor interface {
@@ -72,7 +79,7 @@ type fixedLengthFieldDescriptor struct {
 
 func newFixedLengthFieldDescriptor(
 	fieldType mysql_proto.FieldType_Type,
-	nullable bool,
+	nullable NullableColumn,
 	numBytes int,
 	parseFunc func([]byte) interface{}) FieldDescriptor {
 

--- a/database/binlog/numeric_fields.go
+++ b/database/binlog/numeric_fields.go
@@ -29,7 +29,7 @@ import (
 // NOTE: Field_year is grouped with other temporal fields.
 
 // This returns a field descriptor for FieldType_TINY (i.e., Field_tiny).
-func NewTinyFieldDescriptor(nullable bool) FieldDescriptor {
+func NewTinyFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_TINY,
 		nullable,
@@ -38,7 +38,7 @@ func NewTinyFieldDescriptor(nullable bool) FieldDescriptor {
 }
 
 // This returns a field descriptor for FieldType_SHORT (i.e., Field_shart)
-func NewShortFieldDescriptor(nullable bool) FieldDescriptor {
+func NewShortFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_SHORT,
 		nullable,
@@ -47,7 +47,7 @@ func NewShortFieldDescriptor(nullable bool) FieldDescriptor {
 }
 
 // This returns a field descriptor for FieldType_INT24 (i.e., Field_medium)
-func NewInt24FieldDescriptor(nullable bool) FieldDescriptor {
+func NewInt24FieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_INT24,
 		nullable,
@@ -56,7 +56,7 @@ func NewInt24FieldDescriptor(nullable bool) FieldDescriptor {
 }
 
 // This returns a field descriptor for FieldType_LONG (i.e., Field_long)
-func NewLongFieldDescriptor(nullable bool) FieldDescriptor {
+func NewLongFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_LONG,
 		nullable,
@@ -65,7 +65,7 @@ func NewLongFieldDescriptor(nullable bool) FieldDescriptor {
 }
 
 // This returns a field descriptor for FieldType_LONGLONG (i.e., Field_longlong)
-func NewLongLongFieldDescriptor(nullable bool) FieldDescriptor {
+func NewLongLongFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_LONGLONG,
 		nullable,
@@ -74,7 +74,7 @@ func NewLongLongFieldDescriptor(nullable bool) FieldDescriptor {
 }
 
 // This returns a field descriptor for FieldType_FLOAT (i.e., Field_float)
-func NewFloatFieldDescriptor(nullable bool, metadata []byte) (
+func NewFloatFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {
@@ -100,7 +100,7 @@ func NewFloatFieldDescriptor(nullable bool, metadata []byte) (
 }
 
 // This returns a field descriptor for FieldType_DOUBLE (i.e., Field_double)
-func NewDoubleFieldDescriptor(nullable bool, metadata []byte) (
+func NewDoubleFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {
@@ -128,7 +128,7 @@ type decimalFieldDescriptor struct {
 }
 
 // This returns a field descriptor for FieldType_DECIMAL (i.e., Field_decimal)
-func NewDecimalFieldDescriptor(nullable bool) FieldDescriptor {
+func NewDecimalFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return &decimalFieldDescriptor{
 		baseFieldDescriptor: baseFieldDescriptor{
 			fieldType:  mysql_proto.FieldType_DECIMAL,
@@ -154,7 +154,7 @@ type newDecimalFieldDescriptor struct {
 
 // This returns a field descriptor for FieldType_NEWDECIMAL (i.e.,
 // Field_newdecimal)
-func NewNewDecimalFieldDescriptor(nullable bool, metadata []byte) (
+func NewNewDecimalFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {

--- a/database/binlog/string_fields.go
+++ b/database/binlog/string_fields.go
@@ -65,7 +65,7 @@ func parseTypeAndLength(metadata []byte) (
 }
 
 // This returns a field descriptor for FieldType_NULL (i.e., Field_null)
-func NewNullFieldDescriptor(nullable bool) FieldDescriptor {
+func NewNullFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	// A null field can be nullable ...
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_NULL,
@@ -117,7 +117,7 @@ type stringFieldDescriptor struct {
 }
 
 // This returns a field descriptor for FieldType_VARCHAR (i.e., Field_varstring)
-func NewVarcharFieldDescriptor(nullable bool, metadata []byte) (
+func NewVarcharFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {
@@ -136,7 +136,7 @@ func NewVarcharFieldDescriptor(nullable bool, metadata []byte) (
 
 func NewStringFieldDescriptor(
 	fieldType mysql_proto.FieldType_Type,
-	nullable bool,
+	nullable NullableColumn,
 	maxLen int) FieldDescriptor {
 
 	packedLen := 2
@@ -173,7 +173,7 @@ type blobFieldDescriptor struct {
 }
 
 // This returns a field descriptor for FieldType_BLOB (i.e., Field_blob)
-func NewBlobFieldDescriptor(nullable bool, metadata []byte) (
+func NewBlobFieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {

--- a/database/binlog/table_map_event.go
+++ b/database/binlog/table_map_event.go
@@ -229,7 +229,7 @@ func (p *TableMapEventParser) parseColumns(t *TableMapEvent) error {
 
 		var fd FieldDescriptor
 
-		nullable := nullVector[idx]
+		nullable := NullableColumn(nullVector[idx])
 
 		switch realType {
 		case mysql_proto.FieldType_DECIMAL:

--- a/database/binlog/temporal_fields.go
+++ b/database/binlog/temporal_fields.go
@@ -31,7 +31,7 @@ import (
 //             +--Field_datetimef
 
 // This returns a field descriptor for FieldType_YEAR (i.e., Field_year)
-func NewYearFieldDescriptor(nullable bool) FieldDescriptor {
+func NewYearFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_YEAR,
 		nullable,
@@ -43,7 +43,7 @@ func NewYearFieldDescriptor(nullable bool) FieldDescriptor {
 
 // This returns a fields descriptor for FieldType_TIMESTAMP
 // (i.e., Field_timestamp)
-func NewTimestampFieldDescriptor(nullable bool) FieldDescriptor {
+func NewTimestampFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_TIMESTAMP,
 		nullable,
@@ -56,7 +56,7 @@ func NewTimestampFieldDescriptor(nullable bool) FieldDescriptor {
 // This returns a fields descriptor for FieldType_DATETIME
 // (i.e., Field_datetime).  See number_to_datetime (in sql-common/my_time.c)
 // for encoding detail.
-func NewDateTimeFieldDescriptor(nullable bool) FieldDescriptor {
+func NewDateTimeFieldDescriptor(nullable NullableColumn) FieldDescriptor {
 	return newFixedLengthFieldDescriptor(
 		mysql_proto.FieldType_DATETIME,
 		nullable,
@@ -88,7 +88,7 @@ type usecTemporalFieldDescriptor struct {
 
 func (d *usecTemporalFieldDescriptor) init(
 	fieldType mysql_proto.FieldType_Type,
-	nullable bool,
+	nullable NullableColumn,
 	fixedSize int,
 	metadata []byte) (
 	remaining []byte,
@@ -155,7 +155,7 @@ type timestamp2FieldDescriptor struct {
 // This returns a field descriptor for FieldType_TIMESTAMP2
 // (i.e., Field_timestampf).  See my_timestamp_from_binary (in
 // sql-common/my_time.c) for encoding detail.
-func NewTimestamp2FieldDescriptor(nullable bool, metadata []byte) (
+func NewTimestamp2FieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	remaining []byte,
 	err error) {
@@ -199,7 +199,7 @@ type datetime2FieldDescriptor struct {
 // This returns a field descriptor for FieldType_DATETIME2
 // (i.e., Field_datetimef).  See TIME_from_longlong_datetime_packed (
 // in sql-common/my_time.c) for encoding detail.
-func NewDateTime2FieldDescriptor(nullable bool, metadata []byte) (
+func NewDateTime2FieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
 	reamining []byte,
 	err error) {

--- a/database/sqlbuilder/column.go
+++ b/database/sqlbuilder/column.go
@@ -26,6 +26,13 @@ type Column interface {
 	setTableName(table string) error
 }
 
+type NullableColumn bool
+
+const (
+	Nullable    NullableColumn = true
+	NotNullable NullableColumn = false
+)
+
 // A column that can be refer to outside of the projection list
 type NonAliasColumn interface {
 	Column
@@ -52,7 +59,7 @@ type baseColumn struct {
 	isProjection
 	isExpression
 	name     string
-	nullable bool
+	nullable NullableColumn
 	table    string
 }
 
@@ -88,7 +95,7 @@ type bytesColumn struct {
 
 // Representation of VARBINARY/BLOB columns
 // This function will panic if name is not valid
-func BytesColumn(name string, nullable bool) NonAliasColumn {
+func BytesColumn(name string, nullable NullableColumn) NonAliasColumn {
 	if !validIdentifierName(name) {
 		panic("Invalid column name in bytes column")
 	}
@@ -111,7 +118,7 @@ func StrColumn(
 	name string,
 	charset Charset,
 	collation Collation,
-	nullable bool) NonAliasColumn {
+	nullable NullableColumn) NonAliasColumn {
 
 	if !validIdentifierName(name) {
 		panic("Invalid column name in str column")
@@ -129,7 +136,7 @@ type dateTimeColumn struct {
 
 // Representation of DateTime columns
 // This function will panic if name is not valid
-func DateTimeColumn(name string, nullable bool) NonAliasColumn {
+func DateTimeColumn(name string, nullable NullableColumn) NonAliasColumn {
 	if !validIdentifierName(name) {
 		panic("Invalid column name in datetime column")
 	}
@@ -146,7 +153,7 @@ type integerColumn struct {
 
 // Representation of any integer column
 // This function will panic if name is not valid
-func IntColumn(name string, nullable bool) NonAliasColumn {
+func IntColumn(name string, nullable NullableColumn) NonAliasColumn {
 	if !validIdentifierName(name) {
 		panic("Invalid column name in int column")
 	}
@@ -163,7 +170,7 @@ type doubleColumn struct {
 
 // Representation of any double column
 // This function will panic if name is not valid
-func DoubleColumn(name string, nullable bool) NonAliasColumn {
+func DoubleColumn(name string, nullable NullableColumn) NonAliasColumn {
 	if !validIdentifierName(name) {
 		panic("Invalid column name in int column")
 	}
@@ -183,7 +190,7 @@ type booleanColumn struct {
 
 // Representation of TINYINT used as a bool
 // This function will panic if name is not valid
-func BoolColumn(name string, nullable bool) NonAliasColumn {
+func BoolColumn(name string, nullable NullableColumn) NonAliasColumn {
 	if !validIdentifierName(name) {
 		panic("Invalid column name in bool column")
 	}


### PR DESCRIPTION
This makes it clearer on the calling side what the intention is. Passing raw bools around is usually hard to grok.