### PR TITLE
[sync2] Sleep longer to deflake test

### DIFF
--- a/sync2/semaphore_test.go
+++ b/sync2/semaphore_test.go
@@ -130,7 +130,7 @@ func (suite *SemaphoreSuite) TestLotsOfWaiters(t *C) {
 	}
 
 	s.Increment(2000)
-	time.Sleep(time.Duration(1)*time.Nanosecond)
+	time.Sleep(time.Millisecond)
 
 	for found := 0; found < 1000; found++ {
 		select {


### PR DESCRIPTION
It was continuously failing for me locally with 1ns sleep. 1ms seems to work better.