### PR TITLE
binlog: Return []byte instead of [16]byte

### DIFF
--- a/database/binlog/gtid_log_event.go
+++ b/database/binlog/gtid_log_event.go
@@ -27,8 +27,8 @@ func (e *GtidLogEvent) IsCommit() bool {
 	return e.commit
 }
 
-func (e *GtidLogEvent) Sid() [16]byte {
-	return e.sid
+func (e *GtidLogEvent) Sid() []byte {
+	return e.sid[:]
 }
 
 func (e *GtidLogEvent) Gno() uint64 {


### PR DESCRIPTION
This makes it easier to use outside