### PR TITLE
A leaky bucket rate limiter.

### DIFF
--- a/rate_limiter/rate_limiter.go
+++ b/rate_limiter/rate_limiter.go
@@ -1,0 +1,207 @@
+package rate_limiter
+
+import (
+	"sync"
+	"time"
+
+	"github.com/dropbox/godropbox/errors"
+)
+
+const tickInterval = 100 * time.Millisecond
+const ticksPerSec = 10
+
+// A thread-safe leaky bucket rate limiter.
+type RateLimiter struct {
+	mutex *sync.Mutex
+	cond  *sync.Cond
+
+	maxQuota    float64
+	quotaPerSec float64
+
+	quota float64
+
+	stopped bool
+
+	stopChan chan bool
+
+	ticker *time.Ticker
+
+	// Override during testing (Normally, this is the ticker's channel)
+	tickChan <-chan time.Time
+}
+
+func newRateLimiter() *RateLimiter {
+	m := &sync.Mutex{}
+	t := time.NewTicker(tickInterval)
+
+	return &RateLimiter{
+		mutex:       m,
+		cond:        sync.NewCond(m),
+		maxQuota:    0,
+		quotaPerSec: 0,
+		quota:       0,
+		stopped:     false,
+		stopChan:    make(chan bool),
+		ticker:      t,
+		tickChan:    t.C,
+	}
+}
+
+func NewRateLimiter(
+	maxQuota float64,
+	quotaPerSec float64) (
+	*RateLimiter,
+	error) {
+
+	l := newRateLimiter()
+
+	err := l.SetMaxQuota(maxQuota)
+	if err != nil {
+		return nil, err
+	}
+
+	err = l.SetQuotaPerSec(maxQuota)
+	if err != nil {
+		return nil, err
+	}
+
+	go l.run()
+
+	return l, nil
+}
+
+func (l *RateLimiter) run() {
+	for {
+		select {
+		case <-l.tickChan:
+			l.fillBucket()
+		case <-l.stopChan:
+			return
+		}
+	}
+}
+
+func (l *RateLimiter) fillBucket() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	tickQuota := l.quotaPerSec / ticksPerSec
+
+	l.quota += tickQuota
+	if l.quota > l.maxQuota {
+		l.quota = l.maxQuota
+	}
+
+	l.cond.Signal()
+}
+
+// This returns the leaky bucket's maximum capacity.
+func (l *RateLimiter) MaxQuota() float64 {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.maxQuota
+}
+
+// This sets the leaky bucket's maximum capacity.  The value must be
+// non-negative.
+func (l *RateLimiter) SetMaxQuota(q float64) error {
+	if q < 0 {
+		return errors.Newf("Max quota must be non-negative: %f", q)
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	l.maxQuota = q
+	if l.quota > q {
+		l.quota = q
+	}
+
+	return nil
+}
+
+// This returns the leaky bucket's fill rate.
+func (l *RateLimiter) QuotaPerSec() float64 {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	return l.quotaPerSec
+}
+
+// This sets the leaky bucket's fill rate.  The value must be non-negative.
+func (l *RateLimiter) SetQuotaPerSec(r float64) error {
+	if r < 0 {
+		return errors.Newf("Quota per second must be non-negative: %f", r)
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	l.quotaPerSec = r
+
+	return nil
+}
+
+// This returns the current available quota.
+func (l *RateLimiter) Quota() float64 {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.quota
+}
+
+// Only used for testing.
+func (l *RateLimiter) setQuota(q float64) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.quota = q
+}
+
+// This blocks until the request amount of resources is acquired.  This
+// returns false if the request can be satisfied immediately.  Otherwise, this
+// returns true.
+//
+// NOTE: When maxQuota is zero, or when the rate limiter is stopped,
+// this returns immediately.
+func (l *RateLimiter) Throttle(request float64) bool {
+	if request <= 0 {
+		return false
+	}
+
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	throttled := false
+
+	for {
+		if l.maxQuota <= 0 || l.stopped {
+			return throttled
+		}
+
+		request -= l.quota
+		l.quota = 0
+
+		if request <= 0 {
+			l.quota = -request
+			return throttled
+		}
+
+		l.cond.Wait()
+		throttled = true
+	}
+}
+
+func (l *RateLimiter) Stop() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.stopped {
+		return
+	}
+
+	l.stopped = true
+
+	l.stopChan <- true
+	l.ticker.Stop()
+
+	l.cond.Signal()
+}

--- a/rate_limiter/rate_limiter_test.go
+++ b/rate_limiter/rate_limiter_test.go
@@ -1,0 +1,185 @@
+package rate_limiter
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into go test runner
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type RateLimiterSuite struct {
+	limiter  *RateLimiter
+	tickChan chan time.Time
+}
+
+var _ = Suite(&RateLimiterSuite{})
+
+func (s *RateLimiterSuite) SetUpTest(c *C) {
+	s.tickChan = make(chan time.Time)
+
+	s.limiter = newRateLimiter()
+	s.limiter.tickChan = s.tickChan
+
+	go s.limiter.run()
+}
+
+func (s *RateLimiterSuite) TearDownTest(c *C) {
+	s.limiter.Stop()
+}
+
+func (s *RateLimiterSuite) Tick(c *C) {
+	s.tickChan <- time.Time{}
+	for i := 0; i < 100; i++ {
+		if len(s.tickChan) == 0 {
+			time.Sleep(5 * time.Millisecond)
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	c.FailNow()
+}
+
+func (s *RateLimiterSuite) TestSetMaxQuota(c *C) {
+	s.limiter.setQuota(100)
+	c.Assert(s.limiter.Quota(), Equals, 100.0)
+
+	err := s.limiter.SetMaxQuota(-1)
+	c.Assert(err, NotNil)
+	c.Assert(s.limiter.Quota(), Equals, 100.0)
+	c.Assert(s.limiter.MaxQuota(), Equals, 0.0)
+
+	err = s.limiter.SetMaxQuota(1000)
+	c.Assert(err, IsNil)
+	c.Assert(s.limiter.Quota(), Equals, 100.0)
+	c.Assert(s.limiter.MaxQuota(), Equals, 1000.0)
+
+	err = s.limiter.SetMaxQuota(50)
+	c.Assert(err, IsNil)
+	c.Assert(s.limiter.Quota(), Equals, 50.0)
+	c.Assert(s.limiter.MaxQuota(), Equals, 50.0)
+
+	err = s.limiter.SetMaxQuota(0)
+	c.Assert(err, IsNil)
+	c.Assert(s.limiter.Quota(), Equals, 0.0)
+	c.Assert(s.limiter.MaxQuota(), Equals, 0.0)
+}
+
+func (s *RateLimiterSuite) TestSetQuotaPerSec(c *C) {
+	err := s.limiter.SetQuotaPerSec(-1)
+	c.Assert(err, NotNil)
+	c.Assert(s.limiter.QuotaPerSec(), Equals, 0.0)
+
+	err = s.limiter.SetQuotaPerSec(10)
+	c.Assert(err, IsNil)
+	c.Assert(s.limiter.QuotaPerSec(), Equals, 10.0)
+
+	err = s.limiter.SetQuotaPerSec(0)
+	c.Assert(err, IsNil)
+	c.Assert(s.limiter.QuotaPerSec(), Equals, 0.0)
+}
+
+func (s *RateLimiterSuite) TestFillBucket(c *C) {
+	s.limiter.SetMaxQuota(37)
+	s.limiter.SetQuotaPerSec(40)
+	c.Assert(s.limiter.Quota(), Equals, 0.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 4.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 8.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 12.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 16.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 20.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 24.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 28.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 32.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 36.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 37.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 37.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 37.0)
+	s.limiter.Throttle(10)
+	c.Assert(s.limiter.Quota(), Equals, 27.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 31.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 35.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 37.0)
+	s.Tick(c)
+	c.Assert(s.limiter.Quota(), Equals, 37.0)
+}
+
+func (s *RateLimiterSuite) TestBasicThrottle(c *C) {
+	s.limiter.SetMaxQuota(10)
+	s.limiter.SetQuotaPerSec(10)
+
+	doneChan := make(chan bool)
+	go func() {
+		s.limiter.Throttle(4)
+		doneChan <- true
+	}()
+
+	for i := 0; i < 4; i++ {
+		select {
+		case <-doneChan:
+			c.FailNow()
+		case <-time.After(time.Millisecond):
+			break
+		}
+
+		s.Tick(c)
+	}
+
+	select {
+	case <-doneChan:
+		break
+	case <-time.After(time.Second):
+		c.FailNow()
+	}
+}
+
+func (s *RateLimiterSuite) TestOversizedThrottle(c *C) {
+	s.limiter.SetMaxQuota(10)
+	s.limiter.SetQuotaPerSec(10)
+
+	s.Tick(c)
+	s.Tick(c)
+
+	doneChan := make(chan bool)
+	go func() {
+		s.limiter.Throttle(17)
+		doneChan <- true
+	}()
+
+	for i := 2; i < 17; i++ {
+		select {
+		case <-doneChan:
+			c.FailNow()
+		case <-time.After(time.Millisecond):
+			break
+		}
+
+		s.Tick(c)
+	}
+
+	select {
+	case <-doneChan:
+		break
+	case <-time.After(time.Second):
+		c.FailNow()
+	}
+}


### PR DESCRIPTION
Note: this is slightly different from the original one I wrote for goscribe.  The fill bucket logic is simplified since quota is no longer discrete.  I'm going to get rid of that once this is in.