### PR TITLE
Drop-in replacement for math/rand.

### DIFF
--- a/math2/rand2/rand.go
+++ b/math2/rand2/rand.go
@@ -1,5 +1,6 @@
-// rand2 is a collection of functions meant to supplement the capabilities
-// provided by the standard "math/rand" package.
+// rand2 is a drop-in replacement for the "math/rand" package.  It initializes
+// the global random generator with a random seed (instead of 1), and provides
+// additional functionality over the standard "math/rand" package.
 package rand2
 
 import (
@@ -38,7 +39,7 @@ func NewSource(seed int64) rand.Source {
 	}
 }
 
-// This returns a new Rand.  See rand.New for documentation.
+// This returns a new Rand.  See math/rand for documentation.
 func New(src rand.Source) *rand.Rand {
 	return rand.New(src)
 }
@@ -51,43 +52,43 @@ func init() {
 	globalRand = New(NewSource(seed))
 }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Seed(seed int64) { globalRand.Seed(seed) }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Int63() int64 { return globalRand.Int63() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Uint32() uint32 { return globalRand.Uint32() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Int31() int32 { return globalRand.Int31() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Int() int { return globalRand.Int() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Int63n(n int64) int64 { return globalRand.Int63n(n) }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Int31n(n int32) int32 { return globalRand.Int31n(n) }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Intn(n int) int { return globalRand.Intn(n) }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Float64() float64 { return globalRand.Float64() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Float32() float32 { return globalRand.Float32() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func Perm(n int) []int { return globalRand.Perm(n) }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func NormFloat64() float64 { return globalRand.NormFloat64() }
 
-// See rand for documentation.
+// See math/rand for documentation.
 func ExpFloat64() float64 { return globalRand.ExpFloat64() }
 
 // Samples 'k' unique ints from the range [0, n)

--- a/math2/rand2/rand.go
+++ b/math2/rand2/rand.go
@@ -4,11 +4,91 @@ package rand2
 
 import (
 	"math/rand"
+	"os"
 	"sort"
+	"sync"
+	"time"
 
 	"github.com/dropbox/godropbox/container/set"
 	"github.com/dropbox/godropbox/errors"
 )
+
+type lockedSource struct {
+	mutex sync.Mutex
+	src   rand.Source
+}
+
+func (r *lockedSource) Int63() int64 {
+	r.mutex.Lock()
+	val := r.src.Int63()
+	r.mutex.Unlock()
+	return val
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.mutex.Lock()
+	r.src.Seed(seed)
+	r.mutex.Unlock()
+}
+
+// This returns a thread-safe random source.
+func NewSource(seed int64) rand.Source {
+	return &lockedSource{
+		src: rand.NewSource(seed),
+	}
+}
+
+// This returns a new Rand.  See rand.New for documentation.
+func New(src rand.Source) *rand.Rand {
+	return rand.New(src)
+}
+
+var globalRand *rand.Rand
+
+func init() {
+	now := time.Now()
+	seed := now.Unix() + int64(now.Nanosecond()) + 12345*int64(os.Getpid())
+	globalRand = New(NewSource(seed))
+}
+
+// See rand for documentation.
+func Seed(seed int64) { globalRand.Seed(seed) }
+
+// See rand for documentation.
+func Int63() int64 { return globalRand.Int63() }
+
+// See rand for documentation.
+func Uint32() uint32 { return globalRand.Uint32() }
+
+// See rand for documentation.
+func Int31() int32 { return globalRand.Int31() }
+
+// See rand for documentation.
+func Int() int { return globalRand.Int() }
+
+// See rand for documentation.
+func Int63n(n int64) int64 { return globalRand.Int63n(n) }
+
+// See rand for documentation.
+func Int31n(n int32) int32 { return globalRand.Int31n(n) }
+
+// See rand for documentation.
+func Intn(n int) int { return globalRand.Intn(n) }
+
+// See rand for documentation.
+func Float64() float64 { return globalRand.Float64() }
+
+// See rand for documentation.
+func Float32() float32 { return globalRand.Float32() }
+
+// See rand for documentation.
+func Perm(n int) []int { return globalRand.Perm(n) }
+
+// See rand for documentation.
+func NormFloat64() float64 { return globalRand.NormFloat64() }
+
+// See rand for documentation.
+func ExpFloat64() float64 { return globalRand.ExpFloat64() }
 
 // Samples 'k' unique ints from the range [0, n)
 func SampleInts(n int, k int) (res []int, err error) {
@@ -24,7 +104,7 @@ func SampleInts(n int, k int) (res []int, err error) {
 
 	picked := set.NewSet()
 	for picked.Len() < k {
-		i := rand.Intn(n)
+		i := Intn(n)
 		picked.Add(i)
 	}
 

--- a/net2/http2/load_balanced_pool.go
+++ b/net2/http2/load_balanced_pool.go
@@ -1,7 +1,6 @@
 package http2
 
 import (
-	"math/rand"
 	"net/http"
 	"sort"
 	"sync"
@@ -9,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dropbox/godropbox/errors"
+	"github.com/dropbox/godropbox/math2/rand2"
 )
 
 const (
@@ -105,7 +105,7 @@ func (pool *LoadBalancedPool) Update(instanceInfos []LBPoolInstanceInfo) {
 	case LBRoundRobin:
 		// In RoundRobin strategy, InstanceList is a randomly shuffled list of instances.
 		for i, _ := range newInstanceList {
-			randIdx := rand.Intn(i + 1)
+			randIdx := rand2.Intn(i + 1)
 			newInstanceList.Swap(i, randIdx)
 		}
 	case LBFixed:

--- a/resource_pool/round_robin_resource_pool.go
+++ b/resource_pool/round_robin_resource_pool.go
@@ -1,11 +1,11 @@
 package resource_pool
 
 import (
-	"math/rand"
 	"sync"
 	"sync/atomic"
 
 	"github.com/dropbox/godropbox/errors"
+	"github.com/dropbox/godropbox/math2/rand2"
 )
 
 type ResourceLocationPool struct {
@@ -15,7 +15,7 @@ type ResourceLocationPool struct {
 
 func shuffle(pools []*ResourceLocationPool) {
 	for i := len(pools) - 1; i > 0; i-- {
-		idx := rand.Intn(i + 1)
+		idx := rand2.Intn(i + 1)
 		pools[i], pools[idx] = pools[idx], pools[i]
 	}
 }


### PR DESCRIPTION
rand/math always initialize its global random generator with a seed of 1.  This is retarded since it causes accidential synchronization/collisions across services.