### PR TITLE
[net2] change IP resolution funcction

### DIFF
--- a/net2/ip.go
+++ b/net2/ip.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"os"
 
-	"godropbox/errors"
+	"github.com/dropbox/godropbox/errors"
 )
 
 // This returns the list of local ip addresses which other hosts can connect


### PR DESCRIPTION
So actually what I want to do is to just remove this function and just replace it with the thing that I wrote.
Basically I want to match it to our std python library MY_IP function.

So it goes as:
resolve hostname
resolve ip from hostname

This behaves a lot better in precense of /etc/hosts files or in tests when for example there might not even be any network interfaces.

Let me know how you think would be better to proceed, I can just add new function singletons like:

MyHostname()
MyIP()

Than change rest of the code and just remove this function, or I can keep it similar to how it is here.

@PatrickDropbox @jamwt 