### PR TITLE
[net2] add new self resolving functions

### DIFF
--- a/net2/ip.go
+++ b/net2/ip.go
@@ -5,7 +5,64 @@ import (
 	"os"
 
 	"github.com/dropbox/godropbox/errors"
+	"github.com/dropbox/godropbox/singleton"
 )
+
+var myHostnameSingleton = singleton.NewSingleton(func() (interface{}, error) {
+	return os.Hostname()
+})
+var myIp4Singleton = singleton.NewSingleton(func() (interface{}, error) {
+	hostname, err := MyHostname()
+	if err != nil {
+		return nil, err
+	}
+	ipAddr, err := net.ResolveIPAddr("ip4", hostname)
+	if err != nil {
+		return nil, err
+	}
+	return ipAddr, nil
+})
+var myIp6Singleton = singleton.NewSingleton(func() (interface{}, error) {
+	hostname, err := MyHostname()
+	if err != nil {
+		return nil, err
+	}
+	ipAddr, err := net.ResolveIPAddr("ip6", hostname)
+	if err != nil {
+		return nil, err
+	}
+	return ipAddr, nil
+})
+
+// Like os.Hostname but caches first successful result, making it cheap to call it
+// over and over.
+func MyHostname() (string, error) {
+	if s, err := myHostnameSingleton.Get(); err != nil {
+		return "", err
+	} else {
+		return s.(string), err
+	}
+}
+
+// Resolves `MyHostname()` to an Ip4 address. Caches first successful result, making it
+// cheap to call it over and over.
+func MyIp4() (*net.IPAddr, error) {
+	if s, err := myIp4Singleton.Get(); err != nil {
+		return nil, err
+	} else {
+		return s.(*net.IPAddr), err
+	}
+}
+
+// Resolves `MyHostname()` to an Ip6 address. Caches first successful result, making it
+// cheap to call it over and over.
+func MyIp6() (*net.IPAddr, error) {
+	if s, err := myIp6Singleton.Get(); err != nil {
+		return nil, err
+	} else {
+		return s.(*net.IPAddr), err
+	}
+}
 
 // This returns the list of local ip addresses which other hosts can connect
 // to (NOTE: Loopback ip is ignored).

--- a/net2/ip_test.go
+++ b/net2/ip_test.go
@@ -1,6 +1,8 @@
 package net2
 
 import (
+	"strings"
+
 	. "gopkg.in/check.v1"
 
 	. "github.com/dropbox/godropbox/gocheck2"
@@ -17,4 +19,19 @@ func (s *IpSuite) TestIsLocalhost(c *C) {
 	c.Assert(IsLocalhost("ipv6-localhost"), IsTrue)
 	c.Assert(IsLocalhost("dropbox.com"), IsFalse)
 	c.Assert(IsLocalhost("google.com"), IsFalse)
+}
+
+func (s *IpSuite) TestMyHostnameAndIPs(c *C) {
+	// Just make sure nothing crashes when calling the IP singletons.
+	_, err := MyHostname()
+	c.Assert(err, IsNil)
+	_, err = MyIp4()
+	c.Assert(err, IsNil)
+	_, err = MyIp6()
+	// It is ok to not have Ip6 address, but for now we should make sure we always have Ip4
+	// addresses, since a lot of the code will not work otherwise.
+	c.Assert(
+		(err == nil) || (strings.Contains(err.Error(), "no suitable address found")),
+		Equals,
+		true)
 }


### PR DESCRIPTION
@PatrickDropbox @jamwt @diwakergupta 

I am planning on adding these three functions, and than removing the GetLocalIPs() function. The GetLocalIPs() function is actually quite difficult to use correctly and these three are what should be needed by 99.99% of applications and libraries we have. Rest of them can just use the 'net' library directly if they really want to do something complex.