### PR TITLE
Dialect support among some other smaller changes

### DIFF
--- a/database/sqlbuilder/column_test.go
+++ b/database/sqlbuilder/column_test.go
@@ -28,14 +28,14 @@ func (s *ColumnSuite) TestRealColumnName(c *gc.C) {
 
 func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := IntColumn("col", Nullable)
 
 	// Without table name
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSqlForColumnList(false, db, buf)
+	err := col.SerializeSqlForColumnList(false, d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -47,7 +47,7 @@ func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
 
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSqlForColumnList(true, db, buf)
+	err = col.SerializeSqlForColumnList(true, d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
@@ -56,14 +56,14 @@ func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
 
 func (s *ColumnSuite) TestRealColumnSerializeSql(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := IntColumn("col", Nullable)
 
 	// Without table name
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -75,7 +75,7 @@ func (s *ColumnSuite) TestRealColumnSerializeSql(c *gc.C) {
 
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSql(db, buf)
+	err = col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
@@ -94,12 +94,12 @@ func (s *ColumnSuite) TestAliasColumnName(c *gc.C) {
 
 func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := Alias("foo", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(true, db, buf)
+	err := col.SerializeSqlForColumnList(true, d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -110,34 +110,34 @@ func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnList(c *gc.C) {
 
 func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListNilExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := Alias("foo", nil)
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(false, db, buf)
+	err := col.SerializeSqlForColumnList(false, d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListInvalidAlias(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := Alias("1234", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(false, db, buf)
+	err := col.SerializeSqlForColumnList(false, d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ColumnSuite) TestAliasColumnSerializeSql(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := Alias("foo", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -164,13 +164,13 @@ func (s *ColumnSuite) TestDeferredLookupColumnName(c *gc.C) {
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -179,7 +179,7 @@ func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(c *gc.C)
 	// check cached lookup
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSql(db, buf)
+	err = col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
@@ -188,25 +188,25 @@ func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(c *gc.C)
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnListInvalidName(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSql(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -215,13 +215,13 @@ func (s *ColumnSuite) TestDeferredLookupColumnSerializeSql(c *gc.C) {
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlInvalidName(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 

--- a/database/sqlbuilder/column_test.go
+++ b/database/sqlbuilder/column_test.go
@@ -27,12 +27,15 @@ func (s *ColumnSuite) TestRealColumnName(c *gc.C) {
 }
 
 func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := IntColumn("col", Nullable)
 
 	// Without table name
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSqlForColumnList(buf)
+	err := col.SerializeSqlForColumnList(false, db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -44,7 +47,7 @@ func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
 
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSqlForColumnList(buf)
+	err = col.SerializeSqlForColumnList(true, db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
@@ -52,12 +55,15 @@ func (s *ColumnSuite) TestRealColumnSerializeSqlForColumnList(c *gc.C) {
 }
 
 func (s *ColumnSuite) TestRealColumnSerializeSql(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := IntColumn("col", Nullable)
 
 	// Without table name
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -69,7 +75,7 @@ func (s *ColumnSuite) TestRealColumnSerializeSql(c *gc.C) {
 
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSql(buf)
+	err = col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
@@ -87,10 +93,13 @@ func (s *ColumnSuite) TestAliasColumnName(c *gc.C) {
 }
 
 func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := Alias("foo", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(buf)
+	err := col.SerializeSqlForColumnList(true, db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -100,28 +109,35 @@ func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnList(c *gc.C) {
 }
 
 func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListNilExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := Alias("foo", nil)
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(buf)
+	err := col.SerializeSqlForColumnList(false, db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
-func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListInvalidAlias(
-	c *gc.C) {
+func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListInvalidAlias(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	col := Alias("1234", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSqlForColumnList(buf)
+	err := col.SerializeSqlForColumnList(false, db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ColumnSuite) TestAliasColumnSerializeSql(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := Alias("foo", SqlFunc("max", table1Col1))
 
 	buf := &bytes.Buffer{}
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -146,14 +162,15 @@ func (s *ColumnSuite) TestDeferredLookupColumnName(c *gc.C) {
 	c.Assert(col.Name(), gc.Equals, "foo")
 }
 
-func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(
-	c *gc.C) {
+func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -162,29 +179,34 @@ func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnList(
 	// check cached lookup
 	buf = &bytes.Buffer{}
 
-	err = col.SerializeSql(buf)
+	err = col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql = buf.String()
 	c.Assert(sql, gc.Equals, "`table1`.`col1`")
 }
 
-func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnListInvalidName(
-	c *gc.C) {
+func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlForColumnListInvalidName(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSql(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -192,11 +214,14 @@ func (s *ColumnSuite) TestDeferredLookupColumnSerializeSql(c *gc.C) {
 }
 
 func (s *ColumnSuite) TestDeferredLookupColumnSerializeSqlInvalidName(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 

--- a/database/sqlbuilder/database.go
+++ b/database/sqlbuilder/database.go
@@ -3,12 +3,14 @@ package sqlbuilder
 type Database interface {
 	EscapeCharacter() rune
 	InsertReturningClause() string
+	Kind() string
 	Name() *string
 }
 
 type genericDatabase struct {
 	escapeChar      rune
 	returningClause string
+	kind            string
 	name            *string
 }
 
@@ -20,6 +22,10 @@ func (db *genericDatabase) InsertReturningClause() string {
 	return db.returningClause
 }
 
+func (db *genericDatabase) Kind() string {
+	return db.kind
+}
+
 func (db *genericDatabase) Name() *string {
 	return db.name
 }
@@ -27,6 +33,7 @@ func (db *genericDatabase) Name() *string {
 func NewMySQLDatabase(dbName *string) Database {
 	return &genericDatabase{
 		escapeChar: '`',
+		kind:       "mysql",
 		name:       dbName,
 	}
 }
@@ -35,6 +42,7 @@ func NewPostgresDatabase(dbName *string) Database {
 	return &genericDatabase{
 		escapeChar:      '"',
 		returningClause: " RETURNING *",
+		kind:            "postgres",
 		name:            dbName,
 	}
 }
@@ -43,6 +51,7 @@ func NewSQLiteDatabase() Database {
 	defaultName := "main"
 	return &genericDatabase{
 		escapeChar: '"',
+		kind:       "sqlite",
 		name:       &defaultName,
 	}
 }

--- a/database/sqlbuilder/database.go
+++ b/database/sqlbuilder/database.go
@@ -1,0 +1,48 @@
+package sqlbuilder
+
+type Database interface {
+	EscapeCharacter() rune
+
+	InsertReturningClause() string
+
+	Name() *string
+}
+
+type genericDatabase struct {
+	escapeChar rune
+	returningClause string
+	name *string
+}
+
+func (db *genericDatabase) EscapeCharacter() rune {
+	return db.escapeChar
+}
+
+func (db *genericDatabase) InsertReturningClause() string {
+	return db.returningClause
+}
+
+func (db *genericDatabase) Name() *string {
+	return db.name
+}
+
+func NewMySQLDatabase(dbName *string) Database {
+	return &genericDatabase{
+		escapeChar: '`',
+		name: dbName,
+	}
+}
+
+func NewPostgresDatabase(dbName *string) Database {
+	return &genericDatabase{
+		escapeChar: '"',
+		returningClause: " RETURNING *",
+		name: dbName,
+	}
+}
+
+func NewSQLiteDatabase() Database {
+	return &genericDatabase{
+		escapeChar: '"',
+	}
+}

--- a/database/sqlbuilder/database.go
+++ b/database/sqlbuilder/database.go
@@ -1,45 +1,45 @@
 package sqlbuilder
 
-type Database interface {
+type Dialect interface {
 	EscapeCharacter() rune
 	InsertReturningClause() string
 	Kind() string
 	Name() *string
 }
 
-type genericDatabase struct {
+type genericDialect struct {
 	escapeChar      rune
 	returningClause string
 	kind            string
 	name            *string
 }
 
-func (db *genericDatabase) EscapeCharacter() rune {
+func (db *genericDialect) EscapeCharacter() rune {
 	return db.escapeChar
 }
 
-func (db *genericDatabase) InsertReturningClause() string {
+func (db *genericDialect) InsertReturningClause() string {
 	return db.returningClause
 }
 
-func (db *genericDatabase) Kind() string {
+func (db *genericDialect) Kind() string {
 	return db.kind
 }
 
-func (db *genericDatabase) Name() *string {
+func (db *genericDialect) Name() *string {
 	return db.name
 }
 
-func NewMySQLDatabase(dbName *string) Database {
-	return &genericDatabase{
+func NewMySQLDialect(dbName *string) Dialect {
+	return &genericDialect{
 		escapeChar: '`',
 		kind:       "mysql",
 		name:       dbName,
 	}
 }
 
-func NewPostgresDatabase(dbName *string) Database {
-	return &genericDatabase{
+func NewPostgresDialect(dbName *string) Dialect {
+	return &genericDialect{
 		escapeChar:      '"',
 		returningClause: " RETURNING *",
 		kind:            "postgres",
@@ -47,9 +47,9 @@ func NewPostgresDatabase(dbName *string) Database {
 	}
 }
 
-func NewSQLiteDatabase() Database {
+func NewSQLiteDialect() Dialect {
 	defaultName := "main"
-	return &genericDatabase{
+	return &genericDialect{
 		escapeChar: '"',
 		kind:       "sqlite",
 		name:       &defaultName,

--- a/database/sqlbuilder/database.go
+++ b/database/sqlbuilder/database.go
@@ -2,16 +2,14 @@ package sqlbuilder
 
 type Database interface {
 	EscapeCharacter() rune
-
 	InsertReturningClause() string
-
 	Name() *string
 }
 
 type genericDatabase struct {
-	escapeChar rune
+	escapeChar      rune
 	returningClause string
-	name *string
+	name            *string
 }
 
 func (db *genericDatabase) EscapeCharacter() rune {
@@ -29,20 +27,22 @@ func (db *genericDatabase) Name() *string {
 func NewMySQLDatabase(dbName *string) Database {
 	return &genericDatabase{
 		escapeChar: '`',
-		name: dbName,
+		name:       dbName,
 	}
 }
 
 func NewPostgresDatabase(dbName *string) Database {
 	return &genericDatabase{
-		escapeChar: '"',
+		escapeChar:      '"',
 		returningClause: " RETURNING *",
-		name: dbName,
+		name:            dbName,
 	}
 }
 
 func NewSQLiteDatabase() Database {
+	defaultName := "main"
 	return &genericDatabase{
 		escapeChar: '"',
+		name:       &defaultName,
 	}
 }

--- a/database/sqlbuilder/expression.go
+++ b/database/sqlbuilder/expression.go
@@ -109,7 +109,7 @@ func (conj *conjunctExpression) SerializeSql(database Database, out *bytes.Buffe
 
 	useParentheses := len(clauses) > 1
 	if useParentheses {
-		out.WriteByte('(')
+		out.WriteRune('(')
 	}
 
 	if err = serializeClauses(clauses, conj.conjunction, database, out); err != nil {
@@ -117,7 +117,7 @@ func (conj *conjunctExpression) SerializeSql(database Database, out *bytes.Buffe
 	}
 
 	if useParentheses {
-		out.WriteByte(')')
+		out.WriteRune(')')
 	}
 
 	return nil
@@ -144,7 +144,7 @@ func (arith *arithmeticExpression) SerializeSql(database Database, out *bytes.Bu
 
 	useParentheses := len(clauses) > 1
 	if useParentheses {
-		out.WriteByte('(')
+		out.WriteRune('(')
 	}
 
 	if err = serializeClauses(clauses, arith.operator, database, out); err != nil {
@@ -152,7 +152,7 @@ func (arith *arithmeticExpression) SerializeSql(database Database, out *bytes.Bu
 	}
 
 	if useParentheses {
-		out.WriteByte(')')
+		out.WriteRune(')')
 	}
 
 	return nil
@@ -191,7 +191,7 @@ type listClause struct {
 
 func (list *listClause) SerializeSql(database Database, out *bytes.Buffer) error {
 	if list.includeParentheses {
-		out.WriteByte('(')
+		out.WriteRune('(')
 	}
 
 	if err := serializeClauses(list.clauses, []byte(","), database, out); err != nil {
@@ -199,7 +199,7 @@ func (list *listClause) SerializeSql(database Database, out *bytes.Buffer) error
 	}
 
 	if list.includeParentheses {
-		out.WriteByte(')')
+		out.WriteRune(')')
 	}
 	return nil
 }
@@ -222,7 +222,7 @@ func (c *negateExpression) SerializeSql(database Database, out *bytes.Buffer) (e
 		return
 	}
 
-	out.WriteByte(')')
+	out.WriteRune(')')
 	return nil
 }
 
@@ -643,19 +643,17 @@ type ifExpression struct {
 func (exp *ifExpression) SerializeSql(database Database, out *bytes.Buffer) error {
 	out.WriteString("IF(")
 	exp.conditional.SerializeSql(database, out)
-	out.WriteString(",")
+	out.WriteRune(',')
 	exp.trueExpression.SerializeSql(database, out)
-	out.WriteString(",")
+	out.WriteRune(',')
 	exp.falseExpression.SerializeSql(database, out)
-	out.WriteString(")")
+	out.WriteRune(')')
 	return nil
 }
 
 // Returns a representation of an if-expression, of the form:
 //   IF (BOOLEAN TEST, VALUE-IF-TRUE, VALUE-IF-FALSE)
-func If(conditional BoolExpression,
-	trueExpression Expression,
-	falseExpression Expression) Expression {
+func If(conditional BoolExpression, trueExpression Expression, falseExpression Expression) Expression {
 	return &ifExpression{
 		conditional:     conditional,
 		trueExpression:  trueExpression,
@@ -677,6 +675,6 @@ func ColumnValue(col NonAliasColumn) Expression {
 func (cv *columnValueExpression) SerializeSql(database Database, out *bytes.Buffer) error {
 	out.WriteString("VALUES(")
 	cv.column.SerializeSqlForColumnList(true, database, out)
-	out.WriteByte(')')
+	out.WriteRune(')')
 	return nil
 }

--- a/database/sqlbuilder/expression_test.go
+++ b/database/sqlbuilder/expression_test.go
@@ -12,29 +12,38 @@ type ExprSuite struct {
 var _ = gc.Suite(&ExprSuite{})
 
 func (s *ExprSuite) TestConjunctExprEmptyList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := And()
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestConjunctExprNilInList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := And(nil, EqL(table1Col1, 1))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestConjunctExprSingleElement(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := And(EqL(table1Col1, 1))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -42,76 +51,76 @@ func (s *ExprSuite) TestConjunctExprSingleElement(c *gc.C) {
 }
 
 func (s *ExprSuite) TestTupleExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	expr := Tuple()
 	buf := &bytes.Buffer{}
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 
 	expr = Tuple(table1Col1, Literal(1), Literal("five"))
-	err = expr.SerializeSql(buf)
+	err = expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"(`table1`.`col1`,1,'five')")
-
+	c.Assert(sql, gc.Equals, "(`table1`.`col1`,1,'five')")
 }
 
 func (s *ExprSuite) TestLikeExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := LikeL(table1Col1, EscapeForLike("%my_prefix")+"%")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`table1`.`col1` LIKE '\\%my\\_prefix%'")
-
+	c.Assert(sql, gc.Equals, "`table1`.`col1` LIKE '\\%my\\_prefix%'")
 }
 
 func (s *ExprSuite) TestAndExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := And(EqL(table1Col1, 1), EqL(table1Col2, 2), EqL(table1Col3, 3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"(`table1`.`col1`=1 AND `table1`.`col2`=2 AND `table1`.`col3`=3)")
+	c.Assert(sql, gc.Equals, "(`table1`.`col1`=1 AND `table1`.`col2`=2 AND `table1`.`col3`=3)")
 }
 
 func (s *ExprSuite) TestOrExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Or(EqL(table1Col1, 1), EqL(table1Col2, 2), EqL(table1Col3, 3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"(`table1`.`col1`=1 OR `table1`.`col2`=2 OR `table1`.`col3`=3)")
+	c.Assert(sql, gc.Equals, "(`table1`.`col1`=1 OR `table1`.`col2`=2 OR `table1`.`col3`=3)")
 }
 
 func (s *ExprSuite) TestAddExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Add(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -119,11 +128,14 @@ func (s *ExprSuite) TestAddExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestSubExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Sub(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -131,11 +143,14 @@ func (s *ExprSuite) TestSubExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestMulExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Mul(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -143,11 +158,14 @@ func (s *ExprSuite) TestMulExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestDivExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Div(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -155,20 +173,26 @@ func (s *ExprSuite) TestDivExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestBinaryExprNilLHS(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Gt(nil, table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestNegateExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Not(EqL(table1Col1, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -176,20 +200,26 @@ func (s *ExprSuite) TestNegateExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestBinaryExprNilRHS(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := Lt(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestEqExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := EqL(table1Col1, 321)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -197,11 +227,14 @@ func (s *ExprSuite) TestEqExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestEqExprNilLHS(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := EqL(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -209,11 +242,14 @@ func (s *ExprSuite) TestEqExprNilLHS(c *gc.C) {
 }
 
 func (s *ExprSuite) TestNeqExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := NeqL(table1Col1, 123)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -221,11 +257,14 @@ func (s *ExprSuite) TestNeqExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestNeqExprNilLHS(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := NeqL(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -233,11 +272,14 @@ func (s *ExprSuite) TestNeqExprNilLHS(c *gc.C) {
 }
 
 func (s *ExprSuite) TestLtExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := LtL(table1Col1, -1.5)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -245,11 +287,14 @@ func (s *ExprSuite) TestLtExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestLteExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := LteL(table1Col1, "foo\"';drop user table;")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -260,11 +305,14 @@ func (s *ExprSuite) TestLteExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestGtExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := GtL(table1Col1, 1.1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -272,11 +320,14 @@ func (s *ExprSuite) TestGtExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestGteExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := GteL(table1Col1, 1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -284,12 +335,15 @@ func (s *ExprSuite) TestGteExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestInExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	values := []int32{1, 2, 3}
 	expr := In(table1Col1, values)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -297,12 +351,15 @@ func (s *ExprSuite) TestInExpr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestInExprEmptyList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	values := []int32{}
 	expr := In(table1Col1, values)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -310,20 +367,26 @@ func (s *ExprSuite) TestInExprEmptyList(c *gc.C) {
 }
 
 func (s *ExprSuite) TestSqlFuncExprNilInArgList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := SqlFunc("rand", nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestSqlFuncExprEmptyArgList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := SqlFunc("rand")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -331,11 +394,14 @@ func (s *ExprSuite) TestSqlFuncExprEmptyArgList(c *gc.C) {
 }
 
 func (s *ExprSuite) TestSqlFuncExprNonEmptyArgList(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	expr := SqlFunc("add", table1Col1, table1Col2)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(buf)
+	err := expr.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -343,20 +409,26 @@ func (s *ExprSuite) TestSqlFuncExprNonEmptyArgList(c *gc.C) {
 }
 
 func (s *ExprSuite) TestOrderByClauseNilExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := Asc(nil)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestAsc(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := Asc(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -364,11 +436,14 @@ func (s *ExprSuite) TestAsc(c *gc.C) {
 }
 
 func (s *ExprSuite) TestDesc(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := Desc(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -376,12 +451,15 @@ func (s *ExprSuite) TestDesc(c *gc.C) {
 }
 
 func (s *ExprSuite) TestIf(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	test := GtL(table1Col1, 1.1)
 	clause := If(test, table1Col1, table1Col2)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -392,11 +470,14 @@ func (s *ExprSuite) TestIf(c *gc.C) {
 }
 
 func (s *ExprSuite) TestColumnValue(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := ColumnValue(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -404,11 +485,14 @@ func (s *ExprSuite) TestColumnValue(c *gc.C) {
 }
 
 func (s *ExprSuite) TestBitwiseOr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := BitOr(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -416,11 +500,14 @@ func (s *ExprSuite) TestBitwiseOr(c *gc.C) {
 }
 
 func (s *ExprSuite) TestBitwiseAnd(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := BitAnd(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -428,11 +515,14 @@ func (s *ExprSuite) TestBitwiseAnd(c *gc.C) {
 }
 
 func (s *ExprSuite) TestBitwiseXor(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := BitXor(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -440,11 +530,14 @@ func (s *ExprSuite) TestBitwiseXor(c *gc.C) {
 }
 
 func (s *ExprSuite) TestPlus(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := Plus(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -452,11 +545,14 @@ func (s *ExprSuite) TestPlus(c *gc.C) {
 }
 
 func (s *ExprSuite) TestMinus(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	clause := Minus(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(buf)
+	err := clause.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()

--- a/database/sqlbuilder/expression_test.go
+++ b/database/sqlbuilder/expression_test.go
@@ -558,3 +558,16 @@ func (s *ExprSuite) TestMinus(c *gc.C) {
 	sql := buf.String()
 	c.Assert(sql, gc.Equals, "1 - 2")
 }
+
+func (s *ExprSuite) TestBasicSubquery(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	subquery := table1.Select(table1Col2)
+	outerquery := table1.Select(table1Col1, table1Col2).Where(InQ(table1Col2, Subquery(subquery)))
+
+	sql, err := outerquery.String(db)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` WHERE `table1`.`col2` IN (SELECT `table1`.`col2` FROM `db`.`table1`)")
+}

--- a/database/sqlbuilder/expression_test.go
+++ b/database/sqlbuilder/expression_test.go
@@ -13,37 +13,37 @@ var _ = gc.Suite(&ExprSuite{})
 
 func (s *ExprSuite) TestConjunctExprEmptyList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := And()
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestConjunctExprNilInList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := And(nil, EqL(table1Col1, 1))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestConjunctExprSingleElement(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := And(EqL(table1Col1, 1))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -52,15 +52,15 @@ func (s *ExprSuite) TestConjunctExprSingleElement(c *gc.C) {
 
 func (s *ExprSuite) TestTupleExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Tuple()
 	buf := &bytes.Buffer{}
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 
 	expr = Tuple(table1Col1, Literal(1), Literal("five"))
-	err = expr.SerializeSql(db, buf)
+	err = expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -69,13 +69,13 @@ func (s *ExprSuite) TestTupleExpr(c *gc.C) {
 
 func (s *ExprSuite) TestLikeExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := LikeL(table1Col1, EscapeForLike("%my_prefix")+"%")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -84,13 +84,13 @@ func (s *ExprSuite) TestLikeExpr(c *gc.C) {
 
 func (s *ExprSuite) TestAndExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := And(EqL(table1Col1, 1), EqL(table1Col2, 2), EqL(table1Col3, 3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -99,13 +99,13 @@ func (s *ExprSuite) TestAndExpr(c *gc.C) {
 
 func (s *ExprSuite) TestOrExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Or(EqL(table1Col1, 1), EqL(table1Col2, 2), EqL(table1Col3, 3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -114,13 +114,13 @@ func (s *ExprSuite) TestOrExpr(c *gc.C) {
 
 func (s *ExprSuite) TestAddExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Add(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -129,13 +129,13 @@ func (s *ExprSuite) TestAddExpr(c *gc.C) {
 
 func (s *ExprSuite) TestSubExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Sub(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -144,13 +144,13 @@ func (s *ExprSuite) TestSubExpr(c *gc.C) {
 
 func (s *ExprSuite) TestMulExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Mul(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -159,13 +159,13 @@ func (s *ExprSuite) TestMulExpr(c *gc.C) {
 
 func (s *ExprSuite) TestDivExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Div(Literal(1), Literal(2), Literal(3))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -174,25 +174,25 @@ func (s *ExprSuite) TestDivExpr(c *gc.C) {
 
 func (s *ExprSuite) TestBinaryExprNilLHS(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Gt(nil, table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestNegateExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Not(EqL(table1Col1, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -201,25 +201,25 @@ func (s *ExprSuite) TestNegateExpr(c *gc.C) {
 
 func (s *ExprSuite) TestBinaryExprNilRHS(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := Lt(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestEqExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := EqL(table1Col1, 321)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -228,13 +228,13 @@ func (s *ExprSuite) TestEqExpr(c *gc.C) {
 
 func (s *ExprSuite) TestEqExprNilLHS(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := EqL(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -243,13 +243,13 @@ func (s *ExprSuite) TestEqExprNilLHS(c *gc.C) {
 
 func (s *ExprSuite) TestNeqExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := NeqL(table1Col1, 123)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -258,13 +258,13 @@ func (s *ExprSuite) TestNeqExpr(c *gc.C) {
 
 func (s *ExprSuite) TestNeqExprNilLHS(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := NeqL(table1Col1, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -273,13 +273,13 @@ func (s *ExprSuite) TestNeqExprNilLHS(c *gc.C) {
 
 func (s *ExprSuite) TestLtExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := LtL(table1Col1, -1.5)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -288,13 +288,13 @@ func (s *ExprSuite) TestLtExpr(c *gc.C) {
 
 func (s *ExprSuite) TestLteExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := LteL(table1Col1, "foo\"';drop user table;")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -306,13 +306,13 @@ func (s *ExprSuite) TestLteExpr(c *gc.C) {
 
 func (s *ExprSuite) TestGtExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := GtL(table1Col1, 1.1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -321,13 +321,13 @@ func (s *ExprSuite) TestGtExpr(c *gc.C) {
 
 func (s *ExprSuite) TestGteExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := GteL(table1Col1, 1)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -336,14 +336,14 @@ func (s *ExprSuite) TestGteExpr(c *gc.C) {
 
 func (s *ExprSuite) TestInExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	values := []int32{1, 2, 3}
 	expr := In(table1Col1, values)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -352,14 +352,14 @@ func (s *ExprSuite) TestInExpr(c *gc.C) {
 
 func (s *ExprSuite) TestInExprEmptyList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	values := []int32{}
 	expr := In(table1Col1, values)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -368,25 +368,25 @@ func (s *ExprSuite) TestInExprEmptyList(c *gc.C) {
 
 func (s *ExprSuite) TestSqlFuncExprNilInArgList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := SqlFunc("rand", nil)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestSqlFuncExprEmptyArgList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := SqlFunc("rand")
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -395,13 +395,13 @@ func (s *ExprSuite) TestSqlFuncExprEmptyArgList(c *gc.C) {
 
 func (s *ExprSuite) TestSqlFuncExprNonEmptyArgList(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	expr := SqlFunc("add", table1Col1, table1Col2)
 
 	buf := &bytes.Buffer{}
 
-	err := expr.SerializeSql(db, buf)
+	err := expr.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -410,25 +410,25 @@ func (s *ExprSuite) TestSqlFuncExprNonEmptyArgList(c *gc.C) {
 
 func (s *ExprSuite) TestOrderByClauseNilExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := Asc(nil)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *ExprSuite) TestAsc(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := Asc(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -437,13 +437,13 @@ func (s *ExprSuite) TestAsc(c *gc.C) {
 
 func (s *ExprSuite) TestDesc(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := Desc(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -452,14 +452,14 @@ func (s *ExprSuite) TestDesc(c *gc.C) {
 
 func (s *ExprSuite) TestIf(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	test := GtL(table1Col1, 1.1)
 	clause := If(test, table1Col1, table1Col2)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -471,13 +471,13 @@ func (s *ExprSuite) TestIf(c *gc.C) {
 
 func (s *ExprSuite) TestColumnValue(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := ColumnValue(table1Col1)
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -486,13 +486,13 @@ func (s *ExprSuite) TestColumnValue(c *gc.C) {
 
 func (s *ExprSuite) TestBitwiseOr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := BitOr(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -501,13 +501,13 @@ func (s *ExprSuite) TestBitwiseOr(c *gc.C) {
 
 func (s *ExprSuite) TestBitwiseAnd(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := BitAnd(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -516,13 +516,13 @@ func (s *ExprSuite) TestBitwiseAnd(c *gc.C) {
 
 func (s *ExprSuite) TestBitwiseXor(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := BitXor(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -531,13 +531,13 @@ func (s *ExprSuite) TestBitwiseXor(c *gc.C) {
 
 func (s *ExprSuite) TestPlus(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := Plus(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -546,13 +546,13 @@ func (s *ExprSuite) TestPlus(c *gc.C) {
 
 func (s *ExprSuite) TestMinus(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	clause := Minus(Literal(1), Literal(2))
 
 	buf := &bytes.Buffer{}
 
-	err := clause.SerializeSql(db, buf)
+	err := clause.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -561,12 +561,12 @@ func (s *ExprSuite) TestMinus(c *gc.C) {
 
 func (s *ExprSuite) TestBasicSubquery(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	subquery := table1.Select(table1Col2)
 	outerquery := table1.Select(table1Col1, table1Col2).Where(InQ(table1Col2, Subquery(subquery)))
 
-	sql, err := outerquery.String(db)
+	sql, err := outerquery.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` WHERE `table1`.`col2` IN (SELECT `table1`.`col2` FROM `db`.`table1`)")

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -421,10 +421,12 @@ func (q *selectStatementImpl) String(database Database) (sql string, err error) 
 		}
 	}
 
-	if q.forUpdate {
-		buf.WriteString(" FOR UPDATE")
-	} else if q.withSharedLock {
-		buf.WriteString(" LOCK IN SHARE MODE")
+	if database.Kind() != "sqlite" {
+		if q.forUpdate {
+			buf.WriteString(" FOR UPDATE")
+		} else if q.withSharedLock {
+			buf.WriteString(" LOCK IN SHARE MODE")
+		}
 	}
 
 	return buf.String(), nil

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -367,9 +367,7 @@ func (q *selectStatementImpl) String(database Database) (sql string, err error) 
 	}
 
 	if q.projections == nil || len(q.projections) == 0 {
-		return "", errors.Newf(
-			"No column selected.  Generated sql: %s",
-			buf.String())
+		return "", errors.Newf("No column selected.  Generated sql: %s", buf.String())
 	}
 
 	for i, col := range q.projections {

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -529,7 +529,7 @@ func (s *insertStatementImpl) String(database Database) (sql string, err error) 
 				buf.String())
 		}
 
-		if err = col.SerializeSqlForColumnList(true, database, buf); err != nil {
+		if err = col.SerializeSqlForColumnList(false, database, buf); err != nil {
 			return
 		}
 	}
@@ -586,7 +586,7 @@ func (s *insertStatementImpl) String(database Database) (sql string, err error) 
 					buf.String())
 			}
 
-			if err = colExpr.col.SerializeSqlForColumnList(true, database, buf); err != nil {
+			if err = colExpr.col.SerializeSqlForColumnList(false, database, buf); err != nil {
 				return
 			}
 

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -716,7 +716,7 @@ func (u *updateStatementImpl) String(database Database) (sql string, err error) 
 				buf.String())
 		}
 
-		if err = col.SerializeSqlForColumnList(true, database, buf); err != nil {
+		if err = col.SerializeSqlForColumnList(false, database, buf); err != nil {
 			return
 		}
 

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -219,21 +219,21 @@ func (us *unionStatementImpl) String(database Database) (sql string, err error) 
 
 	if us.where != nil {
 		_, _ = buf.WriteString(" WHERE ")
-		if err = us.where.SerializeSql(buf); err != nil {
+		if err = us.where.SerializeSql(database, buf); err != nil {
 			return
 		}
 	}
 
 	if us.group != nil {
 		_, _ = buf.WriteString(" GROUP BY ")
-		if err = us.group.SerializeSql(buf); err != nil {
+		if err = us.group.SerializeSql(database, buf); err != nil {
 			return
 		}
 	}
 
 	if us.order != nil {
 		_, _ = buf.WriteString(" ORDER BY ")
-		if err = us.order.SerializeSql(buf); err != nil {
+		if err = us.order.SerializeSql(database, buf); err != nil {
 			return
 		}
 	}
@@ -436,10 +436,7 @@ func (q *selectStatementImpl) String(database Database) (sql string, err error) 
 // INSERT Statement ============================================================
 //
 
-func newInsertStatement(
-	t WritableTable,
-	columns ...NonAliasColumn) InsertStatement {
-
+func newInsertStatement(t WritableTable, columns ...NonAliasColumn) InsertStatement {
 	return &insertStatementImpl{
 		table:   t,
 		columns: columns,
@@ -532,7 +529,7 @@ func (s *insertStatementImpl) String(database Database) (sql string, err error) 
 				buf.String())
 		}
 
-		if err = col.SerializeSqlForColumnList(false, database, buf); err != nil {
+		if err = col.SerializeSqlForColumnList(true, database, buf); err != nil {
 			return
 		}
 	}
@@ -589,7 +586,7 @@ func (s *insertStatementImpl) String(database Database) (sql string, err error) 
 					buf.String())
 			}
 
-			if err = colExpr.col.SerializeSqlForColumnList(false, database, buf); err != nil {
+			if err = colExpr.col.SerializeSqlForColumnList(true, database, buf); err != nil {
 				return
 			}
 
@@ -719,7 +716,7 @@ func (u *updateStatementImpl) String(database Database) (sql string, err error) 
 				buf.String())
 		}
 
-		if err = col.SerializeSqlForColumnList(false, database, buf); err != nil {
+		if err = col.SerializeSqlForColumnList(true, database, buf); err != nil {
 			return
 		}
 

--- a/database/sqlbuilder/statement.go
+++ b/database/sqlbuilder/statement.go
@@ -208,13 +208,13 @@ func (us *unionStatementImpl) String(database Database) (sql string, err error) 
 		if i != 0 {
 			buf.WriteString(" UNION ")
 		}
-		_, _ = buf.WriteString("(")
+		_, _ = buf.WriteRune('(')
 		selectSql, err := statement.String(database)
 		if err != nil {
 			return "", err
 		}
 		buf.WriteString(selectSql)
-		_, _ = buf.WriteString(")")
+		_, _ = buf.WriteRune(')')
 	}
 
 	if us.where != nil {

--- a/database/sqlbuilder/statement_test.go
+++ b/database/sqlbuilder/statement_test.go
@@ -259,7 +259,7 @@ func (s *StmtSuite) TestInsertSingleValue(c *gc.C) {
 	sql, err := table1.Insert(table1Col1).Add(Literal(1)).String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`) VALUES (1)")
 }
 
 func (s *StmtSuite) TestInsertDate(c *gc.C) {
@@ -271,7 +271,7 @@ func (s *StmtSuite) TestInsertDate(c *gc.C) {
 	sql, err := table1.Insert(table1Col4).Add(Literal(date)).String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col4`) VALUES ('1999-01-02 03:04:05')")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col4`) VALUES ('1999-01-02 03:04:05')")
 }
 
 func (s *StmtSuite) TestInsertIgnore(c *gc.C) {
@@ -282,7 +282,7 @@ func (s *StmtSuite) TestInsertIgnore(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT IGNORE INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
+	c.Assert(sql, gc.Equals, "INSERT IGNORE INTO `db`.`table1` (`col1`) VALUES (1)")
 }
 
 func (s *StmtSuite) TestInsertMultipleValues(c *gc.C) {
@@ -295,7 +295,7 @@ func (s *StmtSuite) TestInsertMultipleValues(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`,`table1`.`col3`) VALUES (1,2,3)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`,`col3`) VALUES (1,2,3)")
 }
 
 func (s *StmtSuite) TestInsertMultipleRows(c *gc.C) {
@@ -310,7 +310,7 @@ func (s *StmtSuite) TestInsertMultipleRows(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2), (11,22), (111,222)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2), (11,22), (111,222)")
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateNilCol(c *gc.C) {
@@ -348,7 +348,7 @@ func (s *StmtSuite) TestOnDuplicateKeyUpdateSingle(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `table1`.`col3`=3")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `col3`=3")
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
@@ -363,7 +363,7 @@ func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `table1`.`col3`=3, `table1`.`col2`=4")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `col3`=3, `col2`=4")
 }
 
 //

--- a/database/sqlbuilder/statement_test.go
+++ b/database/sqlbuilder/statement_test.go
@@ -406,7 +406,7 @@ func (s *StmtSuite) TestUpdateSingleValue(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2")
 }
 
 func (s *StmtSuite) TestUpdateUsingDeferredLookupColumns(c *gc.C) {
@@ -418,7 +418,7 @@ func (s *StmtSuite) TestUpdateUsingDeferredLookupColumns(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2")
 }
 
 func (s *StmtSuite) TestUpdateMultiValues(c *gc.C) {
@@ -432,7 +432,7 @@ func (s *StmtSuite) TestUpdateMultiValues(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1, `table1`.`col2`=2 WHERE `table1`.`col2`=3")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1, `col2`=2 WHERE `table1`.`col2`=3")
 }
 
 func (s *StmtSuite) TestUpdateWithOrderBy(c *gc.C) {
@@ -445,7 +445,7 @@ func (s *StmtSuite) TestUpdateWithOrderBy(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2 ORDER BY `table1`.`col2`")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2 ORDER BY `table1`.`col2`")
 }
 
 func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
@@ -458,7 +458,7 @@ func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
 	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2 LIMIT 5")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2 LIMIT 5")
 }
 
 //

--- a/database/sqlbuilder/statement_test.go
+++ b/database/sqlbuilder/statement_test.go
@@ -20,203 +20,187 @@ var _ = gc.Suite(&StmtSuite{})
 //
 
 func (s *StmtSuite) TestSelectEmptyProjection(c *gc.C) {
-	_, err := table1.Select().String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Select().String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestSelectSingleColumn(c *gc.C) {
-	sql, err := table1.Select(table1Col1).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	sql, err := table1.Select(table1Col1).String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1`")
 }
 
 func (s *StmtSuite) TestSelectMultiColumns(c *gc.C) {
-	sql, err := table1.Select(table1Col1, table1Col2).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	sql, err := table1.Select(table1Col1, table1Col2).String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1`")
 }
 
 func (s *StmtSuite) TestSelectWhere(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123))
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
 }
 
 func (s *StmtSuite) TestSelectWhereDate(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	date := time.Date(1999, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col4, date))
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` "+
-			"WHERE `table1`.`col4`>'1999-01-02 03:04:05'")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col4`>'1999-01-02 03:04:05'")
 }
 
 func (s *StmtSuite) TestSelectAndWhere(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1).AndWhere(GtL(table1Col1, 123))
 	q.AndWhere(LtL(table1Col1, 321))
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` WHERE (`table1`.`col1`>123 AND `table1`.`col1`<321)")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE (`table1`.`col1`>123 AND `table1`.`col1`<321)")
 }
 
 func (s *StmtSuite) TestSelectCopy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123))
 	qq := q.Copy().Where(GtL(table1Col1, 321)).OrderBy(table1Col1)
 
 	// Initial query unchanged
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
-	// New query changed
-	sql, err = qq.String("db")
-	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>321 ORDER BY `table1`.`col1`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
 
+	// New query changed
+	sql, err = qq.String(db)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>321 ORDER BY `table1`.`col1`")
 }
 
 func (s *StmtSuite) TestSelectLimitWithoutOffset(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1).Limit(5)
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 5")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 5")
 }
 
 func (s *StmtSuite) TestSelectLimitWithOffset(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1).Limit(5).Offset(2)
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 2, 5")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 2, 5")
 }
 
 func (s *StmtSuite) TestSelectGroupBy(c *gc.C) {
-	q := table1.Select(
-		table1Col1,
-		table1Col2,
-		Alias("total", SqlFunc("sum", table1Col3)))
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	q := table1.Select(table1Col1, table1Col2, Alias("total", SqlFunc("sum", table1Col3)))
 	q.GroupBy(table1Col1, table1Col2)
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2`,"+
-			"(sum(`table1`.`col3`)) AS `total` "+
-			"FROM `db`.`table1` GROUP BY `table1`.`col1`,`table1`.`col2`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2`,(sum(`table1`.`col3`)) AS `total` FROM `db`.`table1` GROUP BY `table1`.`col1`,`table1`.`col2`")
 }
 
 func (s *StmtSuite) TestSelectSingleOrderBy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1, table1Col2).OrderBy(table1Col2)
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2` "+
-			"FROM `db`.`table1` ORDER BY `table1`.`col2`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2`")
 }
 
 func (s *StmtSuite) TestSelectOrderByAsc(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1, table1Col2).OrderBy(Asc(table1Col2))
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2` "+
-			"FROM `db`.`table1` ORDER BY `table1`.`col2` ASC")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2` ASC")
 }
 
 func (s *StmtSuite) TestSelectOrderByDesc(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1, table1Col2).OrderBy(Desc(table1Col2))
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2` "+
-			"FROM `db`.`table1` ORDER BY `table1`.`col2` DESC")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2` DESC")
 }
 
 func (s *StmtSuite) TestSelectMultiOrderBy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	q := table1.Select(table1Col1, table1Col2)
 	q.OrderBy(table1Col2, table1Col1)
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table1`.`col2` "+
-			"FROM `db`.`table1` "+
-			"ORDER BY `table1`.`col2`,`table1`.`col1`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2`,`table1`.`col1`")
 }
 
 func (s *StmtSuite) TestSelectOnJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	join := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
-	sql, err := join.Select(table1Col1, table2Col4).String("db")
+	sql, err := join.Select(table1Col1, table2Col4).String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1`,`table2`.`col4` "+
-			"FROM `db`.`table1` JOIN `db`.`table2` "+
-			"ON `table1`.`col3`=`table2`.`col3`")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table2`.`col4` FROM `db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
 }
 
 func (s *StmtSuite) TestSelectWithSharedLock(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123)).WithSharedLock()
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
-	c.Assert(
-		sql,
-		gc.Equals,
-		"SELECT `table1`.`col1` FROM `db`.`table1` "+
-			"WHERE `table1`.`col1`>123 LOCK IN SHARE MODE")
+	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123 LOCK IN SHARE MODE")
 }
 
 //
@@ -224,152 +208,162 @@ func (s *StmtSuite) TestSelectWithSharedLock(c *gc.C) {
 //
 
 func (s *StmtSuite) TestInsertNoColumn(c *gc.C) {
-	_, err := table1.Insert().Add().String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Insert().Add().String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNoRow(c *gc.C) {
-	_, err := table1.Insert(table1Col1).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Insert(table1Col1).String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertColumnLengthMismatch(c *gc.C) {
-	_, err := table1.Insert(table1Col1, table1Col2).Add(nil).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Insert(table1Col1, table1Col2).Add(nil).String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNilValue(c *gc.C) {
-	_, err := table1.Insert(table1Col1).Add(nil).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Insert(table1Col1).Add(nil).String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNilColumn(c *gc.C) {
-	_, err := table1.Insert(nil).Add(Literal(1)).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Insert(nil).Add(Literal(1)).String(db)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertSingleValue(c *gc.C) {
-	sql, err := table1.Insert(table1Col1).Add(Literal(1)).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	sql, err := table1.Insert(table1Col1).Add(Literal(1)).String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
 }
 
 func (s *StmtSuite) TestInsertDate(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	date := time.Date(1999, 1, 2, 3, 4, 5, 0, time.UTC)
 
-	sql, err := table1.Insert(table1Col4).Add(Literal(date)).String("db")
+	sql, err := table1.Insert(table1Col4).Add(Literal(date)).String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` (`table1`.`col4`) "+
-			"VALUES ('1999-01-02 03:04:05')")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col4`) VALUES ('1999-01-02 03:04:05')")
 }
 
 func (s *StmtSuite) TestInsertIgnore(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1).Add(Literal(1)).IgnoreDuplicates(true)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT IGNORE INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
+	c.Assert(sql, gc.Equals, "INSERT IGNORE INTO `db`.`table1` (`table1`.`col1`) VALUES (1)")
 }
 
 func (s *StmtSuite) TestInsertMultipleValues(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2, table1Col3)
 	stmt.Add(Literal(1), Literal(2), Literal(3))
 
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` "+
-			"(`table1`.`col1`,`table1`.`col2`,`table1`.`col3`) "+
-			"VALUES (1,2,3)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`,`table1`.`col3`) VALUES (1,2,3)")
 }
 
 func (s *StmtSuite) TestInsertMultipleRows(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.Add(Literal(11), Literal(22))
 	stmt.Add(Literal(111), Literal(222))
 
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` "+
-			"(`table1`.`col1`,`table1`.`col2`) "+
-			"VALUES (1,2), (11,22), (111,222)")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2), (11,22), (111,222)")
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateNilCol(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(nil, Literal(3))
 
-	_, err := stmt.String("db")
+	_, err := stmt.String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateNilExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col1, nil)
 
-	_, err := stmt.String("db")
+	_, err := stmt.String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateSingle(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col3, Literal(3))
 
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` "+
-			"(`table1`.`col1`,`table1`.`col2`) "+
-			"VALUES (1,2) "+
-			"ON DUPLICATE KEY UPDATE `table1`.`col3`=3")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `table1`.`col3`=3")
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col3, Literal(3))
 	stmt.AddOnDuplicateKeyUpdate(table1Col2, Literal(4))
 
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"INSERT INTO `db`.`table1` "+
-			"(`table1`.`col1`,`table1`.`col2`) "+
-			"VALUES (1,2) "+
-			"ON DUPLICATE KEY UPDATE `table1`.`col3`=3, `table1`.`col2`=4")
+	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`table1`.`col1`,`table1`.`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `table1`.`col3`=3, `table1`.`col2`=4")
 }
 
 //
@@ -377,93 +371,94 @@ func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
 //
 
 func (s *StmtSuite) TestUpdateNilColumn(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(nil, Literal(1))
-	_, err := stmt.String("db")
+	_, err := stmt.String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateNilExpr(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1Col1, nil)
-	_, err := stmt.String("db")
+	_, err := stmt.String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateUnconditionally(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1Col1, Literal(1))
-	_, err := stmt.String("db")
+	_, err := stmt.String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateSingleValue(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
 }
 
 func (s *StmtSuite) TestUpdateUsingDeferredLookupColumns(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1.C("col1"), Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2")
 }
 
 func (s *StmtSuite) TestUpdateMultiValues(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update()
 	stmt.Set(table1Col1, Literal(1))
 	stmt.Set(table1Col2, Literal(2))
 	stmt.Where(EqL(table1Col2, 3))
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"UPDATE `db`.`table1` "+
-			"SET `table1`.`col1`=1, `table1`.`col2`=2 "+
-			"WHERE `table1`.`col2`=3")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1, `table1`.`col2`=2 WHERE `table1`.`col2`=3")
 }
 
 func (s *StmtSuite) TestUpdateWithOrderBy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
 	stmt.OrderBy(table1Col2)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"UPDATE `db`.`table1` "+
-			"SET `table1`.`col1`=1 "+
-			"WHERE `table1`.`col2`=2 "+
-			"ORDER BY `table1`.`col2`")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2 ORDER BY `table1`.`col2`")
 }
 
 func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
 	stmt.Limit(5)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"UPDATE `db`.`table1` "+
-			"SET `table1`.`col1`=1 "+
-			"WHERE `table1`.`col2`=2 "+
-			"LIMIT 5")
+	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `table1`.`col1`=1 WHERE `table1`.`col2`=2 LIMIT 5")
 }
 
 //
@@ -471,42 +466,43 @@ func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
 //
 
 func (s *StmtSuite) TestDeleteUnconditionally(c *gc.C) {
-	_, err := table1.Delete().String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	_, err := table1.Delete().String(db)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestDeleteWithWhere(c *gc.C) {
-	sql, err := table1.Delete().Where(EqL(table1Col1, 1)).String("db")
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
+	sql, err := table1.Delete().Where(EqL(table1Col1, 1)).String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1")
+	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1")
 }
 
 func (s *StmtSuite) TestDeleteWithOrderBy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Delete().Where(EqL(table1Col1, 1)).OrderBy(table1Col1)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"DELETE FROM `db`.`table1` "+
-			"WHERE `table1`.`col1`=1 "+
-			"ORDER BY `table1`.`col1`")
+	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1 ORDER BY `table1`.`col1`")
 }
 
 func (s *StmtSuite) TestDeleteWithLimit(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := table1.Delete().Where(EqL(table1Col1, 1)).Limit(5)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(
-		sql,
-		gc.Equals,
-		"DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1 LIMIT 5")
+	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1 LIMIT 5")
 }
 
 //
@@ -514,22 +510,31 @@ func (s *StmtSuite) TestDeleteWithLimit(c *gc.C) {
 //
 
 func (s *StmtSuite) TestLockStatement(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := NewLockStatement().AddReadLock(table1).AddWriteLock(table2)
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "LOCK TABLES `db`.`table1` READ, `db`.`table2` WRITE")
 }
 
 func (s *StmtSuite) TestUnlockStatement(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	stmt := NewUnlockStatement()
-	sql, err := stmt.String("db")
+	sql, err := stmt.String(db)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "UNLOCK TABLES")
 
 }
 
 func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	select_queries := make([]SelectStatement, 0, 3)
 
 	select_queries = append(select_queries,
@@ -540,7 +545,7 @@ func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
 
 	q := Union(select_queries...)
 
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(
@@ -552,6 +557,9 @@ func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
 }
 
 func (s *StmtSuite) TestUnionLimitWithoutOrderBy(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	select_queries := make([]SelectStatement, 0, 3)
 
 	select_queries = append(select_queries,
@@ -562,16 +570,16 @@ func (s *StmtSuite) TestUnionLimitWithoutOrderBy(c *gc.C) {
 
 	q := Union(select_queries...)
 
-	_, err := q.String("db")
+	_, err := q.String(db)
 
 	c.Assert(err, gc.NotNil)
-	c.Assert(
-		errors.GetMessage(err),
-		gc.Equals,
-		"All inner selects in Union statement must have LIMIT if they have ORDER BY")
+	c.Assert(errors.GetMessage(err), gc.Equals, "All inner selects in Union statement must have LIMIT if they have ORDER BY")
 }
 
 func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	select_queries := make([]SelectStatement, 0, 3)
 
 	select_queries = append(select_queries,
@@ -590,7 +598,7 @@ func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
 	q = q.OrderBy(Desc(table1Col4), Asc(table1Col3))
 	q = q.Limit(5)
 
-	_, err := q.String("db")
+	_, err := q.String(db)
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(
@@ -604,6 +612,8 @@ func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
 }
 
 func (s *StmtSuite) TestComplicatedUnionSelectWithWhereStatement(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
 
 	// tests on outer statement: Group By, Order By, Limit
 	// on inner statement: AndWhere, Where (with And), Order By, Limit
@@ -630,7 +640,7 @@ func (s *StmtSuite) TestComplicatedUnionSelectWithWhereStatement(c *gc.C) {
 	q = q.Limit(5)
 	q = q.GroupBy(table1Col4)
 
-	sql, err := q.String("db")
+	sql, err := q.String(db)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(
@@ -645,5 +655,4 @@ func (s *StmtSuite) TestComplicatedUnionSelectWithWhereStatement(c *gc.C) {
 			"WHERE (`table1`.`col1`<1000 AND `table1`.`col1`>15) "+
 			"GROUP BY `table1`.`col4` ORDER BY `table1`.`col4` DESC,`table1`.`col3` ASC "+
 			"LIMIT 5")
-
 }

--- a/database/sqlbuilder/statement_test.go
+++ b/database/sqlbuilder/statement_test.go
@@ -21,18 +21,18 @@ var _ = gc.Suite(&StmtSuite{})
 
 func (s *StmtSuite) TestSelectEmptyProjection(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Select().String(db)
+	_, err := table1.Select().String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestSelectSingleColumn(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	sql, err := table1.Select(table1Col1).String(db)
+	sql, err := table1.Select(table1Col1).String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1`")
@@ -40,9 +40,9 @@ func (s *StmtSuite) TestSelectSingleColumn(c *gc.C) {
 
 func (s *StmtSuite) TestSelectMultiColumns(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	sql, err := table1.Select(table1Col1, table1Col2).String(db)
+	sql, err := table1.Select(table1Col1, table1Col2).String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1`")
@@ -50,10 +50,10 @@ func (s *StmtSuite) TestSelectMultiColumns(c *gc.C) {
 
 func (s *StmtSuite) TestSelectWhere(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123))
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
@@ -61,12 +61,12 @@ func (s *StmtSuite) TestSelectWhere(c *gc.C) {
 
 func (s *StmtSuite) TestSelectWhereDate(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	date := time.Date(1999, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col4, date))
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col4`>'1999-01-02 03:04:05'")
@@ -74,11 +74,11 @@ func (s *StmtSuite) TestSelectWhereDate(c *gc.C) {
 
 func (s *StmtSuite) TestSelectAndWhere(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).AndWhere(GtL(table1Col1, 123))
 	q.AndWhere(LtL(table1Col1, 321))
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE (`table1`.`col1`>123 AND `table1`.`col1`<321)")
@@ -86,28 +86,28 @@ func (s *StmtSuite) TestSelectAndWhere(c *gc.C) {
 
 func (s *StmtSuite) TestSelectCopy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123))
 	qq := q.Copy().Where(GtL(table1Col1, 321)).OrderBy(table1Col1)
 
 	// Initial query unchanged
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123")
 
 	// New query changed
-	sql, err = qq.String(db)
+	sql, err = qq.String(d)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>321 ORDER BY `table1`.`col1`")
 }
 
 func (s *StmtSuite) TestSelectLimitWithoutOffset(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).Limit(5)
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 5")
@@ -115,10 +115,10 @@ func (s *StmtSuite) TestSelectLimitWithoutOffset(c *gc.C) {
 
 func (s *StmtSuite) TestSelectLimitWithOffset(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).Limit(5).Offset(2)
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` LIMIT 2, 5")
@@ -126,11 +126,11 @@ func (s *StmtSuite) TestSelectLimitWithOffset(c *gc.C) {
 
 func (s *StmtSuite) TestSelectGroupBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1, table1Col2, Alias("total", SqlFunc("sum", table1Col3)))
 	q.GroupBy(table1Col1, table1Col2)
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2`,(sum(`table1`.`col3`)) AS `total` FROM `db`.`table1` GROUP BY `table1`.`col1`,`table1`.`col2`")
@@ -138,10 +138,10 @@ func (s *StmtSuite) TestSelectGroupBy(c *gc.C) {
 
 func (s *StmtSuite) TestSelectSingleOrderBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1, table1Col2).OrderBy(table1Col2)
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2`")
@@ -149,10 +149,10 @@ func (s *StmtSuite) TestSelectSingleOrderBy(c *gc.C) {
 
 func (s *StmtSuite) TestSelectOrderByAsc(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1, table1Col2).OrderBy(Asc(table1Col2))
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2` ASC")
@@ -160,10 +160,10 @@ func (s *StmtSuite) TestSelectOrderByAsc(c *gc.C) {
 
 func (s *StmtSuite) TestSelectOrderByDesc(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1, table1Col2).OrderBy(Desc(table1Col2))
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2` DESC")
@@ -171,11 +171,11 @@ func (s *StmtSuite) TestSelectOrderByDesc(c *gc.C) {
 
 func (s *StmtSuite) TestSelectMultiOrderBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1, table1Col2)
 	q.OrderBy(table1Col2, table1Col1)
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table1`.`col2` FROM `db`.`table1` ORDER BY `table1`.`col2`,`table1`.`col1`")
@@ -183,10 +183,10 @@ func (s *StmtSuite) TestSelectMultiOrderBy(c *gc.C) {
 
 func (s *StmtSuite) TestSelectOnJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
-	sql, err := join.Select(table1Col1, table2Col4).String(db)
+	sql, err := join.Select(table1Col1, table2Col4).String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1`,`table2`.`col4` FROM `db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
@@ -194,10 +194,10 @@ func (s *StmtSuite) TestSelectOnJoin(c *gc.C) {
 
 func (s *StmtSuite) TestSelectWithSharedLock(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	q := table1.Select(table1Col1).Where(GtL(table1Col1, 123)).WithSharedLock()
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "SELECT `table1`.`col1` FROM `db`.`table1` WHERE `table1`.`col1`>123 LOCK IN SHARE MODE")
@@ -209,54 +209,54 @@ func (s *StmtSuite) TestSelectWithSharedLock(c *gc.C) {
 
 func (s *StmtSuite) TestInsertNoColumn(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Insert().Add().String(db)
+	_, err := table1.Insert().Add().String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNoRow(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Insert(table1Col1).String(db)
+	_, err := table1.Insert(table1Col1).String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertColumnLengthMismatch(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Insert(table1Col1, table1Col2).Add(nil).String(db)
+	_, err := table1.Insert(table1Col1, table1Col2).Add(nil).String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNilValue(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Insert(table1Col1).Add(nil).String(db)
+	_, err := table1.Insert(table1Col1).Add(nil).String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertNilColumn(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Insert(nil).Add(Literal(1)).String(db)
+	_, err := table1.Insert(nil).Add(Literal(1)).String(d)
 
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestInsertSingleValue(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	sql, err := table1.Insert(table1Col1).Add(Literal(1)).String(db)
+	sql, err := table1.Insert(table1Col1).Add(Literal(1)).String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`) VALUES (1)")
@@ -264,11 +264,11 @@ func (s *StmtSuite) TestInsertSingleValue(c *gc.C) {
 
 func (s *StmtSuite) TestInsertDate(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	date := time.Date(1999, 1, 2, 3, 4, 5, 0, time.UTC)
 
-	sql, err := table1.Insert(table1Col4).Add(Literal(date)).String(db)
+	sql, err := table1.Insert(table1Col4).Add(Literal(date)).String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col4`) VALUES ('1999-01-02 03:04:05')")
@@ -276,10 +276,10 @@ func (s *StmtSuite) TestInsertDate(c *gc.C) {
 
 func (s *StmtSuite) TestInsertIgnore(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1).Add(Literal(1)).IgnoreDuplicates(true)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT IGNORE INTO `db`.`table1` (`col1`) VALUES (1)")
@@ -287,12 +287,12 @@ func (s *StmtSuite) TestInsertIgnore(c *gc.C) {
 
 func (s *StmtSuite) TestInsertMultipleValues(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2, table1Col3)
 	stmt.Add(Literal(1), Literal(2), Literal(3))
 
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`,`col3`) VALUES (1,2,3)")
@@ -300,14 +300,14 @@ func (s *StmtSuite) TestInsertMultipleValues(c *gc.C) {
 
 func (s *StmtSuite) TestInsertMultipleRows(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.Add(Literal(11), Literal(22))
 	stmt.Add(Literal(111), Literal(222))
 
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2), (11,22), (111,222)")
@@ -315,37 +315,37 @@ func (s *StmtSuite) TestInsertMultipleRows(c *gc.C) {
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateNilCol(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(nil, Literal(3))
 
-	_, err := stmt.String(db)
+	_, err := stmt.String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateNilExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col1, nil)
 
-	_, err := stmt.String(db)
+	_, err := stmt.String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateSingle(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col3, Literal(3))
 
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `col3`=3")
@@ -353,14 +353,14 @@ func (s *StmtSuite) TestOnDuplicateKeyUpdateSingle(c *gc.C) {
 
 func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Insert(table1Col1, table1Col2)
 	stmt.Add(Literal(1), Literal(2))
 	stmt.AddOnDuplicateKeyUpdate(table1Col3, Literal(3))
 	stmt.AddOnDuplicateKeyUpdate(table1Col2, Literal(4))
 
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "INSERT INTO `db`.`table1` (`col1`,`col2`) VALUES (1,2) ON DUPLICATE KEY UPDATE `col3`=3, `col2`=4")
@@ -372,38 +372,38 @@ func (s *StmtSuite) TestOnDuplicateKeyUpdateMulti(c *gc.C) {
 
 func (s *StmtSuite) TestUpdateNilColumn(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(nil, Literal(1))
-	_, err := stmt.String(db)
+	_, err := stmt.String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateNilExpr(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1Col1, nil)
-	_, err := stmt.String(db)
+	_, err := stmt.String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateUnconditionally(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1Col1, Literal(1))
-	_, err := stmt.String(db)
+	_, err := stmt.String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestUpdateSingleValue(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2")
@@ -411,11 +411,11 @@ func (s *StmtSuite) TestUpdateSingleValue(c *gc.C) {
 
 func (s *StmtSuite) TestUpdateUsingDeferredLookupColumns(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1.C("col1"), Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2")
@@ -423,13 +423,13 @@ func (s *StmtSuite) TestUpdateUsingDeferredLookupColumns(c *gc.C) {
 
 func (s *StmtSuite) TestUpdateMultiValues(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update()
 	stmt.Set(table1Col1, Literal(1))
 	stmt.Set(table1Col2, Literal(2))
 	stmt.Where(EqL(table1Col2, 3))
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1, `col2`=2 WHERE `table1`.`col2`=3")
@@ -437,12 +437,12 @@ func (s *StmtSuite) TestUpdateMultiValues(c *gc.C) {
 
 func (s *StmtSuite) TestUpdateWithOrderBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
 	stmt.OrderBy(table1Col2)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2 ORDER BY `table1`.`col2`")
@@ -450,12 +450,12 @@ func (s *StmtSuite) TestUpdateWithOrderBy(c *gc.C) {
 
 func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Update().Set(table1Col1, Literal(1))
 	stmt.Where(EqL(table1Col2, 2))
 	stmt.Limit(5)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "UPDATE `db`.`table1` SET `col1`=1 WHERE `table1`.`col2`=2 LIMIT 5")
@@ -467,17 +467,17 @@ func (s *StmtSuite) TestUpdateWithLimit(c *gc.C) {
 
 func (s *StmtSuite) TestDeleteUnconditionally(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	_, err := table1.Delete().String(db)
+	_, err := table1.Delete().String(d)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *StmtSuite) TestDeleteWithWhere(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
-	sql, err := table1.Delete().Where(EqL(table1Col1, 1)).String(db)
+	sql, err := table1.Delete().Where(EqL(table1Col1, 1)).String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1")
@@ -485,10 +485,10 @@ func (s *StmtSuite) TestDeleteWithWhere(c *gc.C) {
 
 func (s *StmtSuite) TestDeleteWithOrderBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Delete().Where(EqL(table1Col1, 1)).OrderBy(table1Col1)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1 ORDER BY `table1`.`col1`")
@@ -496,10 +496,10 @@ func (s *StmtSuite) TestDeleteWithOrderBy(c *gc.C) {
 
 func (s *StmtSuite) TestDeleteWithLimit(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := table1.Delete().Where(EqL(table1Col1, 1)).Limit(5)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "DELETE FROM `db`.`table1` WHERE `table1`.`col1`=1 LIMIT 5")
@@ -511,10 +511,10 @@ func (s *StmtSuite) TestDeleteWithLimit(c *gc.C) {
 
 func (s *StmtSuite) TestLockStatement(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := NewLockStatement().AddReadLock(table1).AddWriteLock(table2)
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 
 	c.Assert(sql, gc.Equals, "LOCK TABLES `db`.`table1` READ, `db`.`table2` WRITE")
@@ -522,10 +522,10 @@ func (s *StmtSuite) TestLockStatement(c *gc.C) {
 
 func (s *StmtSuite) TestUnlockStatement(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	stmt := NewUnlockStatement()
-	sql, err := stmt.String(db)
+	sql, err := stmt.String(d)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sql, gc.Equals, "UNLOCK TABLES")
 
@@ -533,7 +533,7 @@ func (s *StmtSuite) TestUnlockStatement(c *gc.C) {
 
 func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	select_queries := make([]SelectStatement, 0, 3)
 
@@ -545,7 +545,7 @@ func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
 
 	q := Union(select_queries...)
 
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(
@@ -558,7 +558,7 @@ func (s *StmtSuite) TestUnionSelectStatement(c *gc.C) {
 
 func (s *StmtSuite) TestUnionLimitWithoutOrderBy(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	select_queries := make([]SelectStatement, 0, 3)
 
@@ -570,7 +570,7 @@ func (s *StmtSuite) TestUnionLimitWithoutOrderBy(c *gc.C) {
 
 	q := Union(select_queries...)
 
-	_, err := q.String(db)
+	_, err := q.String(d)
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(errors.GetMessage(err), gc.Equals, "All inner selects in Union statement must have LIMIT if they have ORDER BY")
@@ -578,7 +578,7 @@ func (s *StmtSuite) TestUnionLimitWithoutOrderBy(c *gc.C) {
 
 func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	select_queries := make([]SelectStatement, 0, 3)
 
@@ -598,7 +598,7 @@ func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
 	q = q.OrderBy(Desc(table1Col4), Asc(table1Col3))
 	q = q.Limit(5)
 
-	_, err := q.String(db)
+	_, err := q.String(d)
 
 	c.Assert(err, gc.NotNil)
 	c.Assert(
@@ -613,7 +613,7 @@ func (s *StmtSuite) TestUnionSelectWithMismatchedColumns(c *gc.C) {
 
 func (s *StmtSuite) TestComplicatedUnionSelectWithWhereStatement(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	// tests on outer statement: Group By, Order By, Limit
 	// on inner statement: AndWhere, Where (with And), Order By, Limit
@@ -640,7 +640,7 @@ func (s *StmtSuite) TestComplicatedUnionSelectWithWhereStatement(c *gc.C) {
 	q = q.Limit(5)
 	q = q.GroupBy(table1Col4)
 
-	sql, err := q.String(db)
+	sql, err := q.String(d)
 
 	c.Assert(err, gc.IsNil)
 	c.Assert(

--- a/database/sqlbuilder/table.go
+++ b/database/sqlbuilder/table.go
@@ -18,7 +18,7 @@ type ReadableTable interface {
 	// Generates the sql string for the current table expression.  Note: the
 	// generated string may not be a valid/executable sql statement.
 	// The database is the name of the database the table is on
-	SerializeSql(database Database, out *bytes.Buffer) error
+	SerializeSql(d Dialect, out *bytes.Buffer) error
 
 	// Generates a select query on the current table.
 	Select(projections ...Projection) SelectStatement
@@ -40,8 +40,7 @@ type WritableTable interface {
 
 	// Generates the sql string for the current table expression.  Note: the
 	// generated string may not be a valid/executable sql statement.
-	// The database is the name of the database the table is on
-	SerializeSql(database Database, out *bytes.Buffer) error
+	SerializeSql(d Dialect, out *bytes.Buffer) error
 
 	Insert(columns ...NonAliasColumn) InsertStatement
 	Update() UpdateStatement
@@ -130,25 +129,25 @@ func (t *Table) ForceIndex(index string) *Table {
 
 // Generates the sql string for the current table expression.  Note: the
 // generated string may not be a valid/executable sql statement.
-func (t *Table) SerializeSql(database Database, out *bytes.Buffer) error {
-	if database.Name() != nil {
-		out.WriteRune(database.EscapeCharacter())
-		out.WriteString(*database.Name())
-		out.WriteRune(database.EscapeCharacter())
+func (t *Table) SerializeSql(d Dialect, out *bytes.Buffer) error {
+	if d.Name() != nil {
+		out.WriteRune(d.EscapeCharacter())
+		out.WriteString(*d.Name())
+		out.WriteRune(d.EscapeCharacter())
 		out.WriteByte('.')
 	}
-	out.WriteRune(database.EscapeCharacter())
+	out.WriteRune(d.EscapeCharacter())
 	out.WriteString(t.Name())
-	out.WriteRune(database.EscapeCharacter())
+	out.WriteRune(d.EscapeCharacter())
 
 	if t.forcedIndex != "" {
 		if !validIdentifierName(t.forcedIndex) {
 			return errors.Newf("'%s' is not a valid identifier for an index", t.forcedIndex)
 		}
 		out.WriteString(" FORCE INDEX (")
-		out.WriteRune(database.EscapeCharacter())
+		out.WriteRune(d.EscapeCharacter())
 		out.WriteString(t.forcedIndex)
-		out.WriteRune(database.EscapeCharacter())
+		out.WriteRune(d.EscapeCharacter())
 		out.WriteByte(')')
 	}
 
@@ -258,10 +257,7 @@ func (t *joinTable) Columns() []NonAliasColumn {
 	return columns
 }
 
-func (t *joinTable) SerializeSql(
-	database Database,
-	out *bytes.Buffer) (err error) {
-
+func (t *joinTable) SerializeSql(d Dialect, out *bytes.Buffer) (err error) {
 	if t.lhs == nil {
 		return errors.Newf("nil lhs.  Generated sql: %s", out.String())
 	}
@@ -272,7 +268,7 @@ func (t *joinTable) SerializeSql(
 		return errors.Newf("nil onCondition.  Generated sql: %s", out.String())
 	}
 
-	if err = t.lhs.SerializeSql(database, out); err != nil {
+	if err = t.lhs.SerializeSql(d, out); err != nil {
 		return
 	}
 
@@ -285,12 +281,12 @@ func (t *joinTable) SerializeSql(
 		out.WriteString(" RIGHT JOIN ")
 	}
 
-	if err = t.rhs.SerializeSql(database, out); err != nil {
+	if err = t.rhs.SerializeSql(d, out); err != nil {
 		return
 	}
 
 	out.WriteString(" ON ")
-	if err = t.onCondition.SerializeSql(database, out); err != nil {
+	if err = t.onCondition.SerializeSql(d, out); err != nil {
 		return
 	}
 

--- a/database/sqlbuilder/table.go
+++ b/database/sqlbuilder/table.go
@@ -18,7 +18,7 @@ type ReadableTable interface {
 	// Generates the sql string for the current table expression.  Note: the
 	// generated string may not be a valid/executable sql statement.
 	// The database is the name of the database the table is on
-	SerializeSql(database string, out *bytes.Buffer) error
+	SerializeSql(database Database, out *bytes.Buffer) error
 
 	// Generates a select query on the current table.
 	Select(projections ...Projection) SelectStatement
@@ -41,7 +41,7 @@ type WritableTable interface {
 	// Generates the sql string for the current table expression.  Note: the
 	// generated string may not be a valid/executable sql statement.
 	// The database is the name of the database the table is on
-	SerializeSql(database string, out *bytes.Buffer) error
+	SerializeSql(database Database, out *bytes.Buffer) error
 
 	Insert(columns ...NonAliasColumn) InsertStatement
 	Update() UpdateStatement
@@ -130,20 +130,26 @@ func (t *Table) ForceIndex(index string) *Table {
 
 // Generates the sql string for the current table expression.  Note: the
 // generated string may not be a valid/executable sql statement.
-func (t *Table) SerializeSql(database string, out *bytes.Buffer) error {
-	out.WriteString("`")
-	out.WriteString(database)
-	out.WriteString("`.`")
+func (t *Table) SerializeSql(database Database, out *bytes.Buffer) error {
+	if database.Name() != nil {
+		out.WriteRune(database.EscapeCharacter())
+		out.WriteString(*database.Name())
+		out.WriteRune(database.EscapeCharacter())
+		out.WriteByte('.')
+	}
+	out.WriteRune(database.EscapeCharacter())
 	out.WriteString(t.Name())
-	out.WriteString("`")
+	out.WriteRune(database.EscapeCharacter())
 
 	if t.forcedIndex != "" {
 		if !validIdentifierName(t.forcedIndex) {
 			return errors.Newf("'%s' is not a valid identifier for an index", t.forcedIndex)
 		}
-		out.WriteString(" FORCE INDEX (`")
+		out.WriteString(" FORCE INDEX (")
+		out.WriteRune(database.EscapeCharacter())
 		out.WriteString(t.forcedIndex)
-		out.WriteString("`)")
+		out.WriteRune(database.EscapeCharacter())
+		out.WriteByte(')')
 	}
 
 	return nil
@@ -253,7 +259,7 @@ func (t *joinTable) Columns() []NonAliasColumn {
 }
 
 func (t *joinTable) SerializeSql(
-	database string,
+	database Database,
 	out *bytes.Buffer) (err error) {
 
 	if t.lhs == nil {
@@ -284,7 +290,7 @@ func (t *joinTable) SerializeSql(
 	}
 
 	out.WriteString(" ON ")
-	if err = t.onCondition.SerializeSql(out); err != nil {
+	if err = t.onCondition.SerializeSql(database, out); err != nil {
 		return
 	}
 

--- a/database/sqlbuilder/table_test.go
+++ b/database/sqlbuilder/table_test.go
@@ -25,13 +25,13 @@ func (s *TableSuite) TestBasicColumns(c *gc.C) {
 
 func (s *TableSuite) TestCValidLookup(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -40,30 +40,30 @@ func (s *TableSuite) TestCValidLookup(c *gc.C) {
 
 func (s *TableSuite) TestCInvalidLookup(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(db, buf)
+	err := col.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestValidForcedIndex(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	t := table1.ForceIndex("foo")
 	buf := &bytes.Buffer{}
-	err := t.SerializeSql(db, buf)
+	err := t.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 	sql := buf.String()
 	c.Assert(sql, gc.Equals, "`db`.`table1` FORCE INDEX (`foo`)")
 
 	// Ensure the original table is unchanged
 	buf = &bytes.Buffer{}
-	err = table1.SerializeSql(db, buf)
+	err = table1.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 	sql = buf.String()
 	c.Assert(sql, gc.Equals, "`db`.`table1`")
@@ -71,59 +71,59 @@ func (s *TableSuite) TestValidForcedIndex(c *gc.C) {
 
 func (s *TableSuite) TestInvalidForcedIndex(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	t := table1.ForceIndex("foo\x00")
 	buf := &bytes.Buffer{}
-	err := t.SerializeSql(db, buf)
+	err := t.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilLeftTable(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := InnerJoinOn(nil, table2, EqL(table2Col3, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilRightTable(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := InnerJoinOn(table1, nil, EqL(table2Col3, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilOnCondition(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := InnerJoinOn(table1, table2, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestInnerJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -132,13 +132,13 @@ func (s *TableSuite) TestInnerJoin(c *gc.C) {
 
 func (s *TableSuite) TestLeftJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := table1.LeftJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -147,13 +147,13 @@ func (s *TableSuite) TestLeftJoin(c *gc.C) {
 
 func (s *TableSuite) TestRightJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join := table1.RightJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql(db, buf)
+	err := join.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -175,14 +175,14 @@ func (s *TableSuite) TestJoinColumns(c *gc.C) {
 
 func (s *TableSuite) TestNestedInnerJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.InnerJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql(db, buf)
+	err := join2.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -191,14 +191,14 @@ func (s *TableSuite) TestNestedInnerJoin(c *gc.C) {
 
 func (s *TableSuite) TestNestedLeftJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.LeftJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql(db, buf)
+	err := join2.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -207,14 +207,14 @@ func (s *TableSuite) TestNestedLeftJoin(c *gc.C) {
 
 func (s *TableSuite) TestNestedRightJoin(c *gc.C) {
 	dbName := "db"
-	db := NewMySQLDatabase(&dbName)
+	d := NewMySQLDialect(&dbName)
 
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.RightJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql(db, buf)
+	err := join2.SerializeSql(d, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()

--- a/database/sqlbuilder/table_test.go
+++ b/database/sqlbuilder/table_test.go
@@ -24,11 +24,14 @@ func (s *TableSuite) TestBasicColumns(c *gc.C) {
 }
 
 func (s *TableSuite) TestCValidLookup(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := table1.C("col1")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
@@ -36,109 +39,125 @@ func (s *TableSuite) TestCValidLookup(c *gc.C) {
 }
 
 func (s *TableSuite) TestCInvalidLookup(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	col := table1.C("foo")
 
 	buf := &bytes.Buffer{}
 
-	err := col.SerializeSql(buf)
+	err := col.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestValidForcedIndex(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	t := table1.ForceIndex("foo")
 	buf := &bytes.Buffer{}
-	err := t.SerializeSql("db", buf)
+	err := t.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 	sql := buf.String()
 	c.Assert(sql, gc.Equals, "`db`.`table1` FORCE INDEX (`foo`)")
 
 	// Ensure the original table is unchanged
 	buf = &bytes.Buffer{}
-	err = table1.SerializeSql("db", buf)
+	err = table1.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 	sql = buf.String()
 	c.Assert(sql, gc.Equals, "`db`.`table1`")
 }
 
 func (s *TableSuite) TestInvalidForcedIndex(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	t := table1.ForceIndex("foo\x00")
 	buf := &bytes.Buffer{}
-	err := t.SerializeSql("db", buf)
+	err := t.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilLeftTable(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := InnerJoinOn(nil, table2, EqL(table2Col3, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilRightTable(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := InnerJoinOn(table1, nil, EqL(table2Col3, 123))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestJoinNilOnCondition(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := InnerJoinOn(table1, table2, nil)
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.NotNil)
 }
 
 func (s *TableSuite) TestInnerJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
 }
 
 func (s *TableSuite) TestLeftJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := table1.LeftJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` LEFT JOIN `db`.`table2` "+
-			"ON `table1`.`col3`=`table2`.`col3`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` LEFT JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
 }
 
 func (s *TableSuite) TestRightJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join := table1.RightJoinOn(table2, Eq(table1Col3, table2Col3))
 
 	buf := &bytes.Buffer{}
 
-	err := join.SerializeSql("db", buf)
+	err := join.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` RIGHT JOIN `db`.`table2` "+
-			"ON `table1`.`col3`=`table2`.`col3`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` RIGHT JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3`")
 }
 
 func (s *TableSuite) TestJoinColumns(c *gc.C) {
@@ -155,55 +174,49 @@ func (s *TableSuite) TestJoinColumns(c *gc.C) {
 }
 
 func (s *TableSuite) TestNestedInnerJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.InnerJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql("db", buf)
+	err := join2.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` "+
-			"JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` "+
-			"JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
 }
 
 func (s *TableSuite) TestNestedLeftJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.LeftJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql("db", buf)
+	err := join2.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` "+
-			"JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` "+
-			"LEFT JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` LEFT JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
 }
 
 func (s *TableSuite) TestNestedRightJoin(c *gc.C) {
+	dbName := "db"
+	db := NewMySQLDatabase(&dbName)
+
 	join1 := table1.InnerJoinOn(table2, Eq(table1Col3, table2Col3))
 	join2 := join1.RightJoinOn(table3, Eq(table1Col1, table3Col1))
 
 	buf := &bytes.Buffer{}
 
-	err := join2.SerializeSql("db", buf)
+	err := join2.SerializeSql(db, buf)
 	c.Assert(err, gc.IsNil)
 
 	sql := buf.String()
-	c.Assert(
-		sql,
-		gc.Equals,
-		"`db`.`table1` "+
-			"JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` "+
-			"RIGHT JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
+	c.Assert(sql, gc.Equals, "`db`.`table1` JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` RIGHT JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
 }

--- a/database/sqlbuilder/types.go
+++ b/database/sqlbuilder/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Clause interface {
-	SerializeSql(out *bytes.Buffer) error
+	SerializeSql(database Database, out *bytes.Buffer) error
 }
 
 // A clause that can be used in order by
@@ -29,7 +29,7 @@ type BoolExpression interface {
 type Projection interface {
 	Clause
 	isProjectionInterface
-	SerializeSqlForColumnList(out *bytes.Buffer) error
+	SerializeSqlForColumnList(includeTableName bool, database Database, out *bytes.Buffer) error
 }
 
 //

--- a/database/sqlbuilder/types.go
+++ b/database/sqlbuilder/types.go
@@ -5,11 +5,11 @@ import (
 )
 
 type SubqueryClause interface {
-	SerializeSql(database Database, out *bytes.Buffer) error
+	SerializeSql(d Dialect, out *bytes.Buffer) error
 }
 
 type Clause interface {
-	SerializeSql(database Database, out *bytes.Buffer) error
+	SerializeSql(d Dialect, out *bytes.Buffer) error
 }
 
 // A clause that can be used in order by
@@ -33,7 +33,7 @@ type BoolExpression interface {
 type Projection interface {
 	Clause
 	isProjectionInterface
-	SerializeSqlForColumnList(includeTableName bool, database Database, out *bytes.Buffer) error
+	SerializeSqlForColumnList(includeTableName bool, d Dialect, out *bytes.Buffer) error
 }
 
 //

--- a/database/sqlbuilder/types.go
+++ b/database/sqlbuilder/types.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 )
 
+type SubqueryClause interface {
+	SerializeSql(database Database, out *bytes.Buffer) error
+}
+
 type Clause interface {
 	SerializeSql(database Database, out *bytes.Buffer) error
 }


### PR DESCRIPTION
Hey there,

We're exploring using this library for query composition in porting some Python code that had an ORM to Go. Our application supports SQLite, MySQL, and Postgres, so we've added some basic support for these dialects. I've also added a super naive implementation of `WHERE x in SUBQUERY`.

If these changes interest you guys upstream, I'd be willing to hear some opinions on what we've hacked together so far.