### PR TITLE
Improve the valid Identifiers check

### DIFF
--- a/database/sqlbuilder/column.go
+++ b/database/sqlbuilder/column.go
@@ -254,7 +254,7 @@ func Alias(name string, c Expression) Column {
 }
 
 // This is a strict subset of the actual allowed identifiers
-var validIdentifierRegexp = regexp.MustCompile("^[a-zA-Z_]\\w*$")
+var validIdentifierRegexp = regexp.MustCompile("^[0-9a-zA-Z_]*\\w*[a-zA-Z]\\w*$")
 
 // Returns true if the given string is suitable as an identifier.
 func validIdentifierName(name string) bool {

--- a/database/sqlbuilder/column_test.go
+++ b/database/sqlbuilder/column_test.go
@@ -136,6 +136,16 @@ func (s *ColumnSuite) TestAliasColumnSetTableName(c *gc.C) {
 	c.Assert(err, gc.NotNil)
 }
 
+func (s *ColumnSuite) TestAliasColumnSerializeSqlForColumnListSingleLetterAlias(
+c *gc.C) {
+
+	col := Alias("w", SqlFunc("max", table1Col1))
+
+	buf := &bytes.Buffer{}
+	err := col.SerializeSqlForColumnList(buf)
+	c.Assert(err, gc.IsNil)
+}
+
 //
 // tests for deferredLookkupColumnName
 //


### PR DESCRIPTION
Valid identifiers in mysql can start with a number:

`mysql> create database 9test;
Query OK, 1 row affected (0.00 sec)

mysql> use 9test;
Database changed
mysql> create table 2table( 1col tinyint(1));
Query OK, 0 rows affected (0.05 sec)
`