### PR TITLE
database/binlog: some typo fixes

### DIFF
--- a/database/binlog/format_description_event.go
+++ b/database/binlog/format_description_event.go
@@ -123,7 +123,7 @@ func (p *FormatDescriptionEventParser) Parse(raw *RawV4Event) (Event, error) {
 
 	data, err := readLittleEndian(data, &fde.binlogVersion)
 	if err != nil {
-		return raw, errors.Wrap(err, "Failed to read binlog verison")
+		return raw, errors.Wrap(err, "Failed to read binlog version")
 	}
 
 	serverVersion, data, err := readSlice(data, 50)

--- a/database/binlog/temporal_fields.go
+++ b/database/binlog/temporal_fields.go
@@ -201,12 +201,12 @@ type datetime2FieldDescriptor struct {
 // in sql-common/my_time.c) for encoding detail.
 func NewDateTime2FieldDescriptor(nullable NullableColumn, metadata []byte) (
 	fd FieldDescriptor,
-	reamining []byte,
+	remaining []byte,
 	err error) {
 
 	d := &datetime2FieldDescriptor{}
 
-	remaining, err := d.init(
+	remaining, err = d.init(
 		mysql_proto.FieldType_DATETIME2,
 		nullable,
 		5,


### PR DESCRIPTION
* remove colon from initialization since there is no new variable on the left