### PR TITLE
Call underlying Unregister function

### DIFF
--- a/net2/base_connection_pool.go
+++ b/net2/base_connection_pool.go
@@ -109,9 +109,9 @@ func (p *connectionPoolImpl) Register(network string, address string) error {
 	return p.pool.Register(network + " " + address)
 }
 
-// BaseConnectionPool has nothing to do on Unregister.
+// See ConnectionPool for documentation.
 func (p *connectionPoolImpl) Unregister(network string, address string) error {
-	return nil
+	return p.pool.Unregister(network + " " + address)
 }
 
 func (p *connectionPoolImpl) ListRegistered() []NetworkAddress {


### PR DESCRIPTION
We need to call the underlying Unregister function in order to be able to Unregister connections in a MultiConnectionPool.