### PR TITLE
fix forgotten return in case of invalid line format from memcache ascii client

### DIFF
--- a/memcache/raw_ascii_client.go
+++ b/memcache/raw_ascii_client.go
@@ -672,7 +672,7 @@ func (c *RawAsciiClient) Stat(statsKey string) StatResponse {
 	for {
 		line, err := c.readLine()
 		if err != nil {
-			NewStatErrorResponse(err, shardEntries)
+			return NewStatErrorResponse(err, shardEntries)
 		}
 
 		if line == "END" {


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter (it still in the WIP phase) against `godropbox` repo and it found one suspicious place:
```
2023/12/24 17:03:42 it seems like your code vanished from compiled binary: func=[Stat], file=[/home/sivukhin/code/godropbox/repo/memcache/raw_ascii_client.go], line=[675], snippet:
	NewStatErrorResponse(err, shardEntries)
```

Obviously, this is a bug - `return` statement were forgotten. 

This PR fixes this bug. 